### PR TITLE
Update readme to remove usage of labels in tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ Currently, I only use one virtual environment, even though each folder located a
 ## Development Contribution Process
 The [Rikolti Wiki](https://github.com/ucldc/rikolti/wiki/) contains lots of helpful technical information. The [GitHub Issues](https://github.com/ucldc/rikolti/issues) tool tracks Rikolti development tasks. We organize issues using the GitHub project board [Rikolti MVP](https://github.com/orgs/ucldc/projects/1/views/1) to separate work out into [Milestones](https://github.com/ucldc/rikolti/milestones) and [Sprints](https://github.com/orgs/ucldc/projects/1/views/5). 
 
-All work should be represented by an issue or set of issues. Please create an issue if one does not exist. In order for our project management processes to function smoothly, when creating a new issue, please be sure to include any relevant Assignees, Labels ("mapper/fetcher"), Projects ("Rikolti MVP"), Milestones, and Sprints. 
+All work should be represented by an issue or set of issues. Please create an issue if one does not exist. In order for our project management processes to function smoothly, when creating a new issue, please be sure to include any relevant Assignees, Projects ("Rikolti MVP"), Milestones, and Sprints. 
 
 We use development branches with descriptive names when working on a particular issue or set of issues. Including issue numbers or exact issue names is not necessary. Please use a distinct branch for a distinct piece of work. For example, there should be one development branch for a fetcher, and a different development branch for a mapper - even if the work for the mapper is dependent on the fetcher (you may create a mapper branch with the fetcher branch as the basis). 
 
 When starting work on a given issue, please indicate the date started. If more information is needed to start work on an issue, please @ CDL staff. 
 
 When finishing work on a given issue: 
-1. Create a pull request to the main branch for a code owner to review. Be sure to link the pull request to the issue or set of issues it addresses, and add any relevant Labels, Projects ("Rikolti MVP"), Milestones, and Sprints. 
+1. Create a pull request to the main branch for a code owner to review. Be sure to link the pull request to the issue or set of issues it addresses, and add any relevant Projects ("Rikolti MVP"), Milestones, and Sprints. 
 2. Indicate on the issue the date delivered, and move the issue to the "Ready for Review" state. 
 
 We use PR reviews to approve or reject, comment on, and request further iteration. It's the contributor's responsibility to keep their development branches up-to-date with `main` (or any other designated upstream branches). 


### PR DESCRIPTION
Updated the readme (development contributor process) to remove the usage of the (mapper/fetcher) label.