### PR TITLE
Metadata fetcher testing

### DIFF
--- a/metadata_fetcher/fetch_registry_collections.py
+++ b/metadata_fetcher/fetch_registry_collections.py
@@ -6,12 +6,12 @@ import lambda_function
 import logging
 
 
-def fetch_endpoint(url):
+def fetch_endpoint(url, limit=None):
 
     collection_page = url
     results = []
 
-    while collection_page:
+    while collection_page and (not limit or len(results) < limit):
         response = requests.get(url=collection_page)
         response.raise_for_status()
         total_collections = response.json().get('meta', {}).get('total_count')
@@ -24,8 +24,10 @@ def fetch_endpoint(url):
         if collection_page:
             collection_page = f"https://registry.cdlib.org{collection_page}"
         logging.debug(f"Next page: {collection_page}")
-        collections = response.json().get('objects')
+        collections = response.json().get('objects', [response.json()])
         for collection in collections:
+            if limit and len(results) >= limit:
+                break
             log_msg = f"[{collection['collection_id']}]: " + "{}"
             print(log_msg.format(
                 f"Fetching collection {collection['collection_id']} - "

--- a/metadata_fetcher/fetchers/nuxeo_fetcher.py
+++ b/metadata_fetcher/fetchers/nuxeo_fetcher.py
@@ -6,7 +6,6 @@ from urllib.parse import quote as urllib_quote
 import boto3
 import settings
 import subprocess
-import logging
 
 
 # {'harvest_data': {'harvest_extra_data'}}
@@ -135,7 +134,7 @@ class NuxeoFetcher(Fetcher):
                 'query': query
             }
         }
-        logging.debug(
+        print(
             f"[{self.collection_id}]: Fetching page {page} of {query_type} at "
             f"{self.nuxeo['prefix']} - {current_path['path']}"
         )
@@ -160,7 +159,7 @@ class NuxeoFetcher(Fetcher):
 
         documents = False
         if query_type in ['documents', 'children'] and response.get('entries'):
-            logging.debug(
+            print(
                 f"[{self.collection_id}]: "
                 f"Fetched page {self.nuxeo.get('api_page')} of "
                 f"{query_type} at {self.nuxeo['prefix']} - "
@@ -190,7 +189,7 @@ class NuxeoFetcher(Fetcher):
                 )
 
         if not documents:
-            logging.debug(
+            print(
                 f"[{self.collection_id}]: Fetched page is empty")
 
         return documents

--- a/metadata_fetcher/fetchers/nuxeo_fetcher.py
+++ b/metadata_fetcher/fetchers/nuxeo_fetcher.py
@@ -16,7 +16,7 @@ class NuxeoFetcher(Fetcher):
         "Content-Type": "application/json",
         "X-NXDocumentProperties": "*",
         "X-NXRepository": "default",
-        "X-Authentication-Token": settings.TOKEN
+        "X-Authentication-Token": settings.NUXEO_TOKEN
     }
 
     def __init__(self, params):

--- a/metadata_fetcher/fetchers/oac_fetcher.py
+++ b/metadata_fetcher/fetchers/oac_fetcher.py
@@ -94,7 +94,7 @@ class OacFetcher(Fetcher):
         return bool(len(xml_hits))
 
     def increment(self, http_resp):
-        super(OACFetcher, self).increment(http_resp)
+        super(OacFetcher, self).increment(http_resp)
 
         response = ElementTree.fromstring(http_resp.content)
         current_group = self.oac.get('current_group')

--- a/metadata_fetcher/fetchers/oac_fetcher.py
+++ b/metadata_fetcher/fetchers/oac_fetcher.py
@@ -71,7 +71,7 @@ class OacFetcher(Fetcher):
             f"&group={current_group}"
         )}
         print(
-            f"{self.collection_id}: Fetching page "
+            f"[{self.collection_id}]: Fetching page "
             f"at {request.get('url')}")
 
         return request
@@ -87,7 +87,7 @@ class OacFetcher(Fetcher):
                 f"startDoc={harvested+1}&group={current_group}"
             )
             print(
-                f"{self.collection_id}: Fetched page "
+                f"[{self.collection_id}]: Fetched page "
                 f"at {requested_url} "
                 f"with {len(xml_hits)} hits"
             )

--- a/metadata_fetcher/fetchers/oai_fetcher.py
+++ b/metadata_fetcher/fetchers/oai_fetcher.py
@@ -15,18 +15,18 @@ class OaiFetcher(Fetcher):
 
         self.oai = params.get('harvest_data')
 
-        if self.oai.get('query_params'):
+        if self.oai.get('harvest_extra_data'):
             # see if we have a query string, e.g. "metadataPrefix=marcxml&set=fritz-metcalf"
             parsed_params = {
                 k: v[0] 
-                for k, v in parse_qs(self.oai.get('query_params')).items()
+                for k, v in parse_qs(self.oai.get('harvest_extra_data')).items()
             }
             self.metadata_prefix = parsed_params.get('metadataPrefix')
             self.metadata_set = parsed_params.get('set')
 
             # if not, then assume we just have a string value for set, e.g. "big-pine-citizen-newspaper"
             if not parsed_params:
-                self.metadata_set = self.oai.get('query_params')
+                self.metadata_set = self.oai.get('harvest_extra_data')
         else:
             self.metadata_prefix = self.oai.get('metadata_prefix')
             self.metadata_set = self.oai.get('metadata_set')
@@ -66,7 +66,7 @@ class OaiFetcher(Fetcher):
         request = {"url": url}
 
         print(
-            f"{self.collection_id}: Fetching page {self.write_page} "
+            f"[{self.collection_id}]: Fetching page {self.write_page} "
             f"at {request.get('url')}")
 
         return request
@@ -82,7 +82,7 @@ class OaiFetcher(Fetcher):
                 f"&set={self.metadata_set}"
             )
             print(
-                f"{self.collection_id}: Fetched page {self.write_page} "
+                f"[{self.collection_id}]: Fetched page {self.write_page} "
                 f"at {requested_url} "
                 f"with {len(xml_hits)} hits"
             )

--- a/metadata_fetcher/sample_data/nuxeo_harvests.py
+++ b/metadata_fetcher/sample_data/nuxeo_harvests.py
@@ -8,40 +8,40 @@ nuxeo_harvests = [
     "collection_id": 26695,
     "harvest_type": "nuxeo",
     "write_page": 0,
-    "nuxeo": {
-      "path": "/asset-library/UCI/SCA_UniversityArchives/Publications/Anthill/"
+    "harvest_data": {
+      "root_path": "/asset-library/UCI/SCA_UniversityArchives/Publications/Anthill/"
     }
   }, 
   { # 26098: Ramicova
       'collection_id': 26098,
       'harvest_type': 'nuxeo',
       'write_page': 0,
-      'nuxeo': {
-          'path': "/asset-library/UCM/Ramicova/"
+      "harvest_data": {
+          'root_path': "/asset-library/UCM/Ramicova/"
       }
   },
   { # 26746: Nordskog Papers
     "collection_id": 26746,
     "harvest_type": "nuxeo",
     "write_page": 0,
-    "nuxeo": {
-      "path": "/asset-library/UCR/Water Resources Collections & Archives/Andrae B. Nordskog papers"
+    "harvest_data": {
+      "root_path": "/asset-library/UCR/Water Resources Collections & Archives/Andrae B. Nordskog papers"
     }
   },
   { # 26697: Spectrum
     "collection_id": 26697,
     "harvest_type": "nuxeo",
     "write_page": 0,
-    "nuxeo": {
-      "path": "/asset-library/UCI/SCA_UniversityArchives/Publications/Spectrum/"
+    "harvest_data": {
+      "root_path": "/asset-library/UCI/SCA_UniversityArchives/Publications/Spectrum/"
     }
   },
   { # 27694: Halpern
     "collection_id": 27694,
     "harvest_type": "nuxeo",
     "write_page": 0,
-    "nuxeo": {
-      "path": "/asset-library/UCR/SCUA/Archival/MS075",
+    "harvest_data": {
+      "root_path": "/asset-library/UCR/SCUA/Archival/MS075",
       "fetch_children": True
     }
   },
@@ -49,8 +49,8 @@ nuxeo_harvests = [
     "collection_id": 27141,
     "harvest_type": "nuxeo",
     "write_page": 0,
-    "nuxeo": {
-      "path": "/asset-library/UCR/SCUA/Archival/UA042/published",
+    "harvest_data": {
+      "root_path": "/asset-library/UCR/SCUA/Archival/UA042/published",
       "fetch_children": True
     }
   }
@@ -61,32 +61,32 @@ nuxeo_complex_object_harvests = [
     'collection_id': 466,
     'harvest_type': 'nuxeo',
     'write_page': 0,
-    'nuxeo': {
-        'path': "/asset-library/UCSF/MSS 2000-31 AIDS Ephemera Collection/"
+    "harvest_data": {
+        "root_path": "/asset-library/UCSF/MSS 2000-31 AIDS Ephemera Collection/"
     }
   },
   { # 27012: UC Cooperative Extension
     "collection_id": 27012,
     "harvest_type": "nuxeo",
     "write_page": 0,
-    "nuxeo": {
-      "path": "/asset-library/UCM/UCCE/Merced/PUBLISH/"
+    "harvest_data": {
+      "root_path": "/asset-library/UCM/UCCE/Merced/PUBLISH/"
     }
   },
   { # 68: McLean
     "collection_id": 68,
     "harvest_type": "nuxeo",
     "write_page": 0,
-    "nuxeo": {
-      "path": "/asset-library/UCM/McLean/Publish/"
+    "harvest_data": {
+      "root_path": "/asset-library/UCM/McLean/Publish/"
     }
   },
   { # 76: Nightingale
     "collection_id": 76,
     "harvest_type": "nuxeo",
     "write_page": 0,
-    "nuxeo": {
-      "path": "/asset-library/UCM/NightingaleDiaries/",
+    "harvest_data": {
+      "root_path": "/asset-library/UCM/NightingaleDiaries/",
       "fetch_children": True
     }
   }
@@ -97,8 +97,8 @@ nuxeo_nested_complex_object_harvests = [
     "collection_id": 14256,
     "harvest_type": "nuxeo",
     "write_page": 0,
-    "nuxeo": {
-      "path": "/asset-library/UCM/Wilma_McDaniel/Publish/"
+    "harvest_data": {
+      "root_path": "/asset-library/UCM/Wilma_McDaniel/Publish/"
     }
   }
 ]

--- a/metadata_fetcher/sample_data/oac_harvests.py
+++ b/metadata_fetcher/sample_data/oac_harvests.py
@@ -3,7 +3,7 @@ oac_harvests = [
     "collection_id": 22973,
     "harvest_type": "oac",
     "write_page": 0,
-    "oac": {
+    "harvest_data": {
       "url": "http://dsc.cdlib.org/search?facet=type-tab&style=cui&raw=1&relation=ark:/13030/kt28702559"
     }
   },
@@ -11,7 +11,7 @@ oac_harvests = [
     "collection_id": 22456,
     "harvest_type": "oac",
     "write_page": 0,
-    "oac": {
+    "harvest_data": {
       "url": "http://dsc.cdlib.org/search?facet=type-tab&style=cui&raw=1&relation=ark:/13030/c8pn97ch"
     }
   },
@@ -19,25 +19,8 @@ oac_harvests = [
     "collection_id": 25496,
     "harvest_type": "oac",
     "write_page": 0,
-    "oac": {
+    "harvest_data": {
       'url': 'http://dsc.cdlib.org/search?facet=type-tab&style=cui&raw=1&relation=ark:/13030/hb8779p2cx&publisher=%22bancroft%22'
     }
   }
 ]
-
-oac_datel_harvests = [{
-  'collection_id': f"{harvest['collection_id']}-datel",
-  'harvest_type': 'DatelOACFetcher',
-  'write_page': 0,
-  'oac': harvest['oac']
-} for harvest in oac_harvests]
-
-json_endpoint_url = "http://dsc-dsc2-dev.cdlib.org/search?facet=type-tab&style=cui&rmode=json&relation="
-oac_json_harvests = [{
-  "collection_id": f"{harvest['collection_id']}-json",
-  "harvest_type": "JsonOAC",
-  "write_page": 0,
-  "oac": {
-    "url": json_endpoint_url + harvest['oac']['url'].split('&relation=')[1]
-  }
-} for harvest in oac_harvests]

--- a/metadata_fetcher/sample_data/oai_harvests.py
+++ b/metadata_fetcher/sample_data/oai_harvests.py
@@ -5,7 +5,7 @@ oai_harvests = [
     "harvest_type": "oai",
     "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
-      "query_params": "pvld_4833"
+      "harvest_extra_data": "pvld_4833"
     }
   },
   {
@@ -14,7 +14,7 @@ oai_harvests = [
     "harvest_type": "oai",
     "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
-      "query_params": "pvld_4048"
+      "harvest_extra_data": "pvld_4048"
     }
   },
   {
@@ -23,7 +23,7 @@ oai_harvests = [
     "harvest_type": "oai",
     "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
-      "query_params": "pvld_4020"
+      "harvest_extra_data": "pvld_4020"
     }
   },
   {
@@ -32,7 +32,7 @@ oai_harvests = [
     "harvest_type": "oai",
     "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
-      "query_params": "pvld_4017"
+      "harvest_extra_data": "pvld_4017"
     }
   },
   {
@@ -41,7 +41,7 @@ oai_harvests = [
     "harvest_type": "oai",
     "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
-      "query_params": "pvld_2"
+      "harvest_extra_data": "pvld_2"
     }
   },
   {
@@ -50,7 +50,7 @@ oai_harvests = [
     "harvest_type": "oai",
     "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
-      "query_params": "pvld_4256"
+      "harvest_extra_data": "pvld_4256"
     }
   },
   {
@@ -59,7 +59,7 @@ oai_harvests = [
     "harvest_type": "oai",
     "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
-      "query_params": "pvld_4406"
+      "harvest_extra_data": "pvld_4406"
     }
   },
   {
@@ -68,7 +68,7 @@ oai_harvests = [
     "harvest_type": "oai",
     "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
-      "query_params": "pvld_homes"
+      "harvest_extra_data": "pvld_homes"
     }
   },
   {
@@ -79,7 +79,7 @@ oai_harvests = [
     'harvest_type': "oai",
     "harvest_data": {
         'url': "https://digicoll.lib.berkeley.edu/oai2d",
-        'query_params': "metadataPrefix=marcxml&set=sugoroku"
+        'harvest_extra_data': "metadataPrefix=marcxml&set=sugoroku"
     }
   },
   {
@@ -91,7 +91,7 @@ oai_harvests = [
     "harvest_type": "oai",
     "harvest_data": {
       "url": "http://oai.quartexcollections.com/lmudigitalcollections/oai2",
-      "query_params": "big-pine-citizen-newspaper"
+      "harvest_extra_data": "big-pine-citizen-newspaper"
     }
   },
   {
@@ -104,7 +104,7 @@ oai_harvests = [
     "harvest_type": "oai",
     "harvest_data": {
       "url": "https://digicoll.lib.berkeley.edu/oai2d",
-      "query_params": "metadataPrefix=marcxml&set=fritz-metcalf"
+      "harvest_extra_data": "metadataPrefix=marcxml&set=fritz-metcalf"
     }
   },
   {
@@ -115,7 +115,7 @@ oai_harvests = [
     "harvest_type": "oai",
     "harvest_data": {
       "url": "https://glbt.i8.dgicloud.com/oai/request",
-      "query_params": "node:23758"
+      "harvest_extra_data": "node:23758"
     }
   }
 ]

--- a/metadata_fetcher/sample_data/oai_harvests.py
+++ b/metadata_fetcher/sample_data/oai_harvests.py
@@ -3,8 +3,7 @@ oai_harvests = [
     # 26773 OAI Marineland - 18 items
     "collection_id": 26773,
     "harvest_type": "oai",
-    "write_page": 0,
-    "oai": {
+    "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
       "query_params": "pvld_4833"
     }
@@ -13,8 +12,7 @@ oai_harvests = [
     # 26774 OAI Palos Verdes Bulletin - 82 items
     "collection_id": 26774,
     "harvest_type": "oai",
-    "write_page": 0,
-    "oai": {
+    "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
       "query_params": "pvld_4048"
     }
@@ -23,8 +21,7 @@ oai_harvests = [
     # 26775 OAI Palos Verdes College Photo Collection - 225 items
     "collection_id": 26775,
     "harvest_type": "oai",
-    "write_page": 0,
-    "oai": {
+    "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
       "query_params": "pvld_4020"
     }
@@ -33,8 +30,7 @@ oai_harvests = [
     # 26776 OAI Phillips Ranch Photo Collection - 69 items
     "collection_id": 26776,
     "harvest_type": "oai",
-    "write_page": 0,
-    "oai": {
+    "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
       "query_params": "pvld_4017"
     }
@@ -43,8 +39,7 @@ oai_harvests = [
     # 26777 OAI Postcard Collection - 95 items
     "collection_id": 26777,
     "harvest_type": "oai",
-    "write_page": 0,
-    "oai": {
+    "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
       "query_params": "pvld_2"
     }
@@ -53,8 +48,7 @@ oai_harvests = [
     # 26778 OAI Your Story is the Peninsula's Story Collection - 90 items
     "collection_id": 26778,
     "harvest_type": "oai",
-    "write_page": 0,
-    "oai": {
+    "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
       "query_params": "pvld_4256"
     }
@@ -63,8 +57,7 @@ oai_harvests = [
     # 26779 OAI Malaga Cove Star Newspaper - 28 items
     "collection_id": 26779,
     "harvest_type": "oai",
-    "write_page": 0,
-    "oai": {
+    "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
       "query_params": "pvld_4406"
     }
@@ -73,74 +66,56 @@ oai_harvests = [
     # 26885 OAI Palos Verdes Homes Association Photo Collection - 1775 items
     "collection_id": 26885,
     "harvest_type": "oai",
-    "write_page": 0,
-    "oai": {
+    "harvest_data": {
       "url": "http://www.palosverdeshistory.org/oai2",
       "query_params": "pvld_homes"
     }
   },
-  { # 27435: Sugoroku
+  {
+    # 27435: Sugoroku
     # 155 items
     # extra_data: metadataPrefix=marcxml&set=sugoroku
     'collection_id': 27435,
     'harvest_type': "oai",
-    'write_page': 0,
-    'oai': {
+    "harvest_data": {
         'url': "https://digicoll.lib.berkeley.edu/oai2d",
         'query_params': "metadataPrefix=marcxml&set=sugoroku"
     }
   },
-]
-
-'''
-oai_harvests = [
-  { # 2206: Big Pine Citizen Newspaper
+  {
+    # 2206: Big Pine Citizen Newspaper
     # 19 items
     # extra_data: big-pine-citizen-newspaper
     # curl 'http://oai.quartexcollections.com/lmudigitalcollections/oai2?verb=ListMetadataFormats'
     "collection_id": 2206,
     "harvest_type": "oai",
-    "write_page": 0,
-    "oai": {
+    "harvest_data": {
       "url": "http://oai.quartexcollections.com/lmudigitalcollections/oai2",
       "query_params": "big-pine-citizen-newspaper"
     }
   },
-  { # 27435: Sugoroku
-    # 155 items
-    # extra_data: metadataPrefix=marcxml&set=sugoroku
-    'collection_id': 27435,
-    'harvest_type': "oai",
-    'write_page': 0,
-    'oai': {
-        'url': "https://digicoll.lib.berkeley.edu/oai2d",
-        'query_params': "metadataPrefix=marcxml&set=sugoroku"
-    }
-  },
-  { # 26693: Fritz-Metcalf
+  {
+    # 26693: Fritz-Metcalf
     # 8,729 items
     # extra_data: metadataPrefix=marcxml&set=fritz-metcalf
     # curl 'https://digicoll.lib.berkeley.edu/oai2d?verb=ListRecords&metadataPrefix=marcxml' > sample_data/fritz-metcalf.xm
     # <resumptionToken completeListSize="46849" cursor="0" expirationDate="2022-10-12T21:50:56Z">___AzfqSX</resumptionToken>
     "collection_id": 26693,
     "harvest_type": "oai",
-    "write_page": 0, 
-    "oai": {
+    "harvest_data": {
       "url": "https://digicoll.lib.berkeley.edu/oai2d",
       "query_params": "metadataPrefix=marcxml&set=fritz-metcalf"
     }
   },
-  { # 27934: San Francisco Gay Men's Chorus records, 2009-01
+  {
+    # 27934: San Francisco Gay Men's Chorus records, 2009-01
     # 47 items
     # extra_data: node:23758
-    # 
     "collection_id": 27934,
     "harvest_type": "oai",
-    "write_page": 0,
-    "oai": {
+    "harvest_data": {
       "url": "https://glbt.i8.dgicloud.com/oai/request",
       "query_params": "node:23758"
     }
   }
 ]
-'''

--- a/metadata_fetcher/settings.py
+++ b/metadata_fetcher/settings.py
@@ -4,7 +4,7 @@ LOCAL_RUN = os.environ.get('FETCHER_LOCAL_RUN', False)
 DATA_DEST = os.environ.get('FETCHER_DATA_DEST', 's3')
 LOG_LEVEL = os.environ.get('LOG_LEVEL', 'DEBUG')    # doesn't currently do anything
 S3_BUCKET = os.environ.get('S3_BUCKET', False)
-TOKEN = os.environ.get('NUXEO')
+NUXEO_TOKEN = os.environ.get('NUXEO')
 
 if not LOCAL_RUN and DATA_DEST == 'local':
     print(

--- a/metadata_fetcher/tests.py
+++ b/metadata_fetcher/tests.py
@@ -1,12 +1,17 @@
 from lambda_function import fetch_collection
-from sample_data.nuxeo_harvests import *
-from sample_data.oac_harvests import *
-from sample_data.oai_harvests import *
+from sample_data.nuxeo_harvests import nuxeo_harvests, \
+    nuxeo_complex_object_harvests, nuxeo_nested_complex_object_harvests
+from sample_data.oac_harvests import oac_harvests
+from sample_data.oai_harvests import oai_harvests
 import json
 
-harvests = oac_harvests
-#  + nuxeo_complex_object_harvests + nuxeo_nested_complex_object_harvests
+harvests = [
+    # nuxeo_harvests[1], nuxeo_complex_object_harvests[0],
+    # nuxeo_nested_complex_object_harvests[0],
+    oac_harvests[0], oai_harvests[0]
+]
+
 for harvest in harvests:
     print(f"tests.py: {json.dumps(harvest)}")
-    fetch_collection(json.dumps(harvest), {})
-    print(f"Harvested: {str(harvest)}")
+    status = fetch_collection(json.dumps(harvest), {})
+    print(f"Harvest status: {status}")

--- a/metadata_fetcher/tests.py
+++ b/metadata_fetcher/tests.py
@@ -10,7 +10,7 @@ import settings
 harvests = [
     oac_harvests[0], oai_harvests[0]
 ]
-if settings.TOKEN:
+if settings.NUXEO_TOKEN:
     harvests = harvests + [
         nuxeo_harvests[0], nuxeo_complex_object_harvests[0],
         nuxeo_nested_complex_object_harvests[0]
@@ -33,7 +33,7 @@ urls = [
     "https://registry.cdlib.org/api/v1/rikoltifetcher/26773/?format=json"
 ]
 
-if settings.TOKEN:
+if settings.NUXEO_TOKEN:
     urls = urls + [
         # harvest type = NUX
         "https://registry.cdlib.org/api/v1/rikoltifetcher/?format=json&harvest_type=NUX",

--- a/metadata_fetcher/tests.py
+++ b/metadata_fetcher/tests.py
@@ -3,15 +3,43 @@ from sample_data.nuxeo_harvests import nuxeo_harvests, \
     nuxeo_complex_object_harvests, nuxeo_nested_complex_object_harvests
 from sample_data.oac_harvests import oac_harvests
 from sample_data.oai_harvests import oai_harvests
+from fetch_registry_collections import fetch_endpoint
 import json
+import settings
 
 harvests = [
-    # nuxeo_harvests[1], nuxeo_complex_object_harvests[0],
-    # nuxeo_nested_complex_object_harvests[0],
     oac_harvests[0], oai_harvests[0]
 ]
+if settings.TOKEN:
+    harvests = harvests + [
+        nuxeo_harvests[0], nuxeo_complex_object_harvests[0],
+        nuxeo_nested_complex_object_harvests[0]
+    ]
 
 for harvest in harvests:
     print(f"tests.py: {json.dumps(harvest)}")
     status = fetch_collection(json.dumps(harvest), {})
     print(f"Harvest status: {status}")
+
+urls = [
+    # harvest type = OAC
+    "https://registry.cdlib.org/api/v1/rikoltifetcher/?format=json&harvest_type=OAC",
+    "https://registry.cdlib.org/api/v1/rikoltifetcher/?format=json&mapper_type=oac_dc&offset=5",
+    "https://registry.cdlib.org/api/v1/rikoltifetcher/9/?format=json",
+    # harvest type = OAI
+    "https://registry.cdlib.org/api/v1/rikoltifetcher/?format=json&harvest_type=OAI",
+    "https://registry.cdlib.org/api/v1/rikoltifetcher/?format=json&mapper_type=islandora_oai_dc",
+    "https://registry.cdlib.org/api/v1/rikoltifetcher/?format=json&mapper_type=cca_vault_oai_dc",
+    "https://registry.cdlib.org/api/v1/rikoltifetcher/26773/?format=json"
+]
+
+if settings.TOKEN:
+    urls = urls + [
+        # harvest type = NUX
+        "https://registry.cdlib.org/api/v1/rikoltifetcher/?format=json&harvest_type=NUX",
+        "https://registry.cdlib.org/api/v1/rikoltifetcher/?format=json&mapper_type=ucldc_nuxeo",
+        "https://registry.cdlib.org/api/v1/rikoltifetcher/22/?format=json",
+    ]
+
+for url in urls:
+    fetch_endpoint(url, 1)


### PR DESCRIPTION
`metadata_fetcher$ python tests.py` now functional for both json records stored in `metadata_fetcher/sample_data` and Collection API endpoints filtered by harvest type, mapper type, and for individual collections. 