### PR TITLE
Deprecate mapper methods

### DIFF
--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -6,6 +6,7 @@ import boto3
 from abc import ABC, abstractmethod
 from markupsafe import Markup
 from typing import Any, Union
+from deprecated import deprecated
 
 import settings
 
@@ -137,15 +138,13 @@ class Record(ABC, object):
                 collated.extend(value)
         return collated
 
+    @deprecated(reason="replace with `collate_plucked_values()` in mappers that use it")
     def collate_subfield(self, field, subfield):
-        """DEPRECATED: replace with `collate_plucked_values()` in mappers that use it"""
         return [f[subfield] for f in self.source_metadata.get(field, [])]
 
+    @deprecated(reason="replace with `collate_values()` in mappers that use it")
     def collate_fields(self, fieldlist):
-        """multiple field values into a single list
-
-        DEPRECATED: replace with `collate_values()` in mappers that use it
-        """
+        """multiple field values into a single list"""
         return self.collate_values([self.source_metadata.get(field) for field in fieldlist])
 
     def source_metadata_values(self, *args):

--- a/metadata_mapper/requirements.txt
+++ b/metadata_mapper/requirements.txt
@@ -4,3 +4,4 @@ lxml
 sickle
 MarkupSafe
 python-dotenv
+python-deprecated


### PR DESCRIPTION
I meant to include this in the mapper refactor PR but never pushed it. Not urgent, can follow other things.