### PR TITLE
WIP: Implement contentdm_oai_dc

### DIFF
--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -90,6 +90,8 @@ def collate_values(values):
 def first(item):
     return item[0] if item else None
 
+def last(item):
+    return item[-1] if item else None
 
 class Record(ABC, object):
 
@@ -97,7 +99,7 @@ class Record(ABC, object):
         self.collection_id: int = collection_id
         self.source_metadata: dict = record
         # TODO: pre_mapped_data is a stop gap to accomodate
-        # pre-mapper enrichments, should probably squash this. 
+        # pre-mapper enrichments, should probably squash this.
         self.pre_mapped_data = {}
         self.enrichment_report = []
 
@@ -329,7 +331,7 @@ class Record(ABC, object):
 
         # TODO: this is a way to get around cases where a key with name <field>
         # it present in self.mapped_data, but the value is None. Should get rid
-        # of these keys in the first place. 
+        # of these keys in the first place.
         if field not in self.mapped_data or not self.mapped_data[field]:
             return self
 

--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -69,6 +69,28 @@ class Vernacular(ABC, object):
         return api_response
 
 
+# Static mapping helpers
+def collate_plucked_values(values: list, pluck: str) -> list:
+    return [f[pluck] for f in values]
+
+
+def collate_values(values):
+    collated = []
+    for value in values:
+        if not value:
+            continue
+
+        if isinstance(value, str):
+            collated.append(value)
+        else:
+            collated.extend(value)
+    return collated
+
+
+def first(item):
+    return item[0] if item else None
+
+
 class Record(ABC, object):
 
     def __init__(self, collection_id: int, record: dict[str, Any]):
@@ -128,20 +150,6 @@ class Record(ABC, object):
         pass
 
     # Mapper Helpers
-    def collate_plucked_values(self, values: list, pluck: str) -> list:
-        return [f[pluck] for f in values]
-
-    def collate_values(self, values):
-        collated = []
-        for value in values:
-            if not value:
-                continue
-
-            if isinstance(value, str):
-                collated.append(value)
-            else:
-                collated.extend(value)
-        return collated
 
     @deprecated(reason="replace with `collate_plucked_values()` in mappers that use it")
     def collate_subfield(self, field, subfield):
@@ -150,7 +158,7 @@ class Record(ABC, object):
     @deprecated(reason="replace with `collate_values()` in mappers that use it")
     def collate_fields(self, fieldlist):
         """multiple field values into a single list"""
-        return self.collate_values([self.source_metadata.get(field) for field in fieldlist])
+        return collate_values([self.source_metadata.get(field) for field in fieldlist])
 
     def source_metadata_values(self, *args):
         return [self.source_metadata.get(field) for field in args]
@@ -289,13 +297,13 @@ class Record(ABC, object):
                 self.mapped_data[field] += (field_value)
             else:
                 self.mapped_data[field] = field_value
-        else:   # default is fill if empty
+        else:  # default is fill if empty
             if field not in self.mapped_data:
                 self.mapped_data[field] = field_value
 
         # not sure what this is about
         # if not exists(data, "@context"):
-            # self.mapped_data["@context"] = "http://dp.la/api/items/context"
+        # self.mapped_data["@context"] = "http://dp.la/api/items/context"
         return self
 
     def shred(self, prop, delim=";"):
@@ -402,8 +410,8 @@ class Record(ABC, object):
         src_val = self.mapped_data.get(src)
         dest_val = self.mapped_data.get(dest, [])
         if (
-              (not (isinstance(src_val, list) or isinstance(src_val, str))) or
-              (not (isinstance(dest_val, list) or isinstance(dest_val, str)))
+                (not (isinstance(src_val, list) or isinstance(src_val, str))) or
+                (not (isinstance(dest_val, list) or isinstance(dest_val, str)))
         ):
             self.enrichment_report.append(
                 f"[copy_prop]: Prop {src} is {type(src_val)} and prop {dest} "
@@ -1122,7 +1130,7 @@ class Record(ABC, object):
 
         for field in default_fields + dont_strip_trailing_dot:
             # TODO: this won't work for deeply nested fields
-            field.split('/')[1]     # remove sourceResource
+            field.split('/')[1]  # remove sourceResource
 
             if field not in self.mapped_data:
                 continue

--- a/metadata_mapper/mappers/oai/chapman_oai_dc_mapper.py
+++ b/metadata_mapper/mappers/oai/chapman_oai_dc_mapper.py
@@ -11,7 +11,7 @@ class ChapmanOaiDcRecord(OaiRecord):
 
     def UCLDC_map(self):
         return {
-            'description': self.collate_values([
+            'description': collate_values([
                 self.source_metadata.get('abstract'),
                 self.map_description(),
                 self.source_metadata.get('tableOfContents')

--- a/metadata_mapper/mappers/oai/contentdm/arck_oai_dc_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/arck_oai_dc_mapper.py
@@ -1,0 +1,21 @@
+from ..contentdm_oai_dc_mapper import ContentdmOaiDcRecord, ContentdmOaiDcVernacular
+
+class ArckOaiDcRecord(ContentdmOaiDcRecord):
+    @staticmethod
+    def __identifier_match():
+        return "view/ARCK3D"
+
+    def map_is_shown_by(self):
+        return self.get_last_match(self.source_metadata.get("relation", "/thumbnail"))
+
+    def map_source(self):
+        return self.source_metadata.get("source")
+
+    def map_relation(self):
+        if self.map_is_shown_at():
+            return
+
+        return self.source_metadata.get("relation")
+
+class ContentdmOaiDcVernacular(ContentdmOaiDcVernacular):
+    record_cls = ContentdmOaiDcRecord

--- a/metadata_mapper/mappers/oai/contentdm/blackgold_oai_dc_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/blackgold_oai_dc_mapper.py
@@ -1,0 +1,19 @@
+from typing import Union
+
+from ..contentdm_oai_dc_mapper import ContentdmOaiDcRecord, ContentdmOaiDcVernacular
+
+class ArckOaiDcRecord(ContentdmOaiDcRecord):
+    @staticmethod
+    def __identifier_match():
+        return "luna/servlet/detail"
+
+    def map_is_shown_by(self):
+        value = self.get_last_match(self.source_metadata.get("identifier", "mediafile="))
+        if not value:
+            return
+
+        return value.replace("Size2", "Size4")
+
+
+class ContentdmOaiDcVernacular(ContentdmOaiDcVernacular):
+    record_cls = ContentdmOaiDcRecord

--- a/metadata_mapper/mappers/oai/contentdm/chico_oai_dc-mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/chico_oai_dc-mapper.py
@@ -1,0 +1,27 @@
+from ..contentdm_oai_dc_mapper import ContentdmOaiDcRecord, ContentdmOaiDcVernacular
+from ..oai_mapper import collate_values
+
+
+class ChicoOaiDcRecord(ContentdmOaiDcRecord):
+    def UCLDC_map(self):
+        """Removing `created`, see: https://github.com/calisphere-legacy-harvester/dpla-ingestion/blob/ucldc/lib/mappers/chico_oai_mapper.py
+
+        """
+        return {
+            'date': collate_values(
+                self.source_metadata_values(
+                    'available',
+                    'date',
+                    'dateAccepted',
+                    'dateCopyrighted',
+                    'dateSubmitted',
+                    'issued',
+                    'modified',
+                    'valid'
+                )
+            )
+        }
+
+
+class ChicoOaiDcVernacular(ContentdmOaiDcVernacular):
+    record_cls = ChicoOaiDcRecord

--- a/metadata_mapper/mappers/oai/contentdm/cvpl_oai_dc_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/cvpl_oai_dc_mapper.py
@@ -1,0 +1,40 @@
+from ..contentdm_oai_dc_mapper import ContentdmOaiDcRecord, ContentdmOaiDcVernacular
+from ..oai_mapper import last
+
+class CvplOaiDcRecord(ContentdmOaiDcRecord):
+    @staticmethod
+    def __identifier_match():
+        return "//archives.chulavistalibrary.com"
+
+    def get_larger_preview_image_url(self):
+        """
+        TODO: look into multiple matches on identifier, like the following function
+
+        """
+        identifier = last(self.get_matches(self.source_metadata.get("identifier"), self.__identifier_match()))
+        if not identifier:
+            return
+
+        base_url, _, collection_comma_object = identifier.rsplit('/', 2)
+        collection_id, object_id = collection_comma_object.split(',')
+        return ''.join((base_url, '/cgi-bin',
+                                 '/getimage.exe?DMSCALE=20&CISOROOT=/', collection_id,
+                                 '&CISOPTR=', object_id))
+
+
+    def map_is_shown_at(self):
+        """
+        According to the legacy mapper, this match requires both the domain, and the "cdm/ref" value
+        from the parent mapper. See: https://github.com/calisphere-legacy-harvester/dpla-ingestion/blob/ucldc/lib/mappers/chula_vista_pl_contentdm_oai_dc_mapper.py
+
+        TODO: this requires another pass to see if sibling mappers also require multiple match strings on the identifier
+
+        """
+        with_domain = self.get_matches(self.source_metadata.get("identifier"), self.__identifier_match())
+        return last(self.get_matches(with_domain, "cdm/ref"))
+
+
+
+
+class CvplOaiDcVernacular(ContentdmOaiDcVernacular):
+    record_cls = CvplOaiDcRecord

--- a/metadata_mapper/mappers/oai/contentdm_oai_dc_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm_oai_dc_mapper.py
@@ -1,0 +1,154 @@
+from typing import Union
+
+from .oai_mapper import OaiRecord, OaiVernacular, first
+
+class ContentdmOaiDcRecord(OaiRecord):
+    @staticmethod
+    def __identifier_match(self):
+        return "cdm/ref"
+
+    def get_first_match(self, items: dict, match: str):
+        return first(self.get_matches(items, match))
+
+    def get_matches(self, items: dict, match: str):
+        [item for item in items if match in item]
+
+    def map_is_shown_by(self):
+        identifier = self.get_first_match(self.source_metadata.get("identifier", self.__identifier_match()))
+        if not identifier:
+            return
+
+        base_url, i, j, k, collection_id, l, object_id = identifier.rsplit('/', 6)
+        return '/'.join((base_url, 'utils', 'getthumbnail',
+                                  'collection', collection_id, 'id', object_id))
+
+
+    def map_is_shown_at(self):
+        return self.get_first_match(self.source_metadata.get("identifier", self._ident_match))
+
+    """This is where we're at"""
+
+
+    def map_contributor(self):
+        self.to_source_resource_with_split('contributor', 'contributor')
+
+    def map_creator(self):
+        self.to_source_resource_with_split('creator', 'creator')
+
+    def map_subject(self):
+        values = self.split_values('subject')
+        subject_objs = [{'name': v} for v in values]
+        self.update_source_resource({'subject': subject_objs})
+
+    def map_spatial(self):
+        fields = ('coverage', 'spatial')
+        self.source_resource_orig_list_to_prop_with_split(fields, 'spatial')
+
+    def map_type(self):
+        '''TODO:Funky, but map_type comes after the is_shown_by, should change order
+        '''
+        self.to_source_resource_with_split('type', 'type')
+
+    def map_language(self):
+        self.to_source_resource_with_split('language', 'language')
+
+    def get_url_image_info(self):
+        image_info = {'height': 0, 'width': 0}
+        ident = self.get_identifier_match('cdm/ref')
+        base_url, i, j, k, collid, l, objid = ident.rsplit('/', 6)
+        # url_image_info give json data about image for record
+        url_image_info = '/'.join((base_url, 'utils', 'ajaxhelper'))
+        url_image_info = '{}?CISOROOT={}&CISOPTR={}'.format(url_image_info,
+                                                            collid, objid)
+        logger.error(url_image_info)
+        return url_image_info
+
+    def get_image_info(self):
+        '''Return image info for the contentdm object'''
+        image_info = {'height': 0, 'width': 0}
+        ident = self.get_identifier_match('cdm/ref')
+        if ident:
+            image_info = requests.get(self.get_url_image_info()).json()[
+                'imageinfo']
+        return image_info
+
+    def get_larger_preview_image(self):
+        # Try to get a bigger image than the thumbnail.
+        # Some "text" types have a large image
+        image_info = self.get_image_info()
+        if image_info['height'] > 0:  # if 0 only thumb available
+            # figure scaling
+            max_dim = 1024.0
+            scale = 100
+            if image_info['height'] >= image_info['width']:
+                scale = int((max_dim / image_info['height']) * 100)
+            else:
+                scale = int((max_dim / image_info['width']) * 100)
+            scale = 100 if scale > 100 else scale
+            thumbnail_url = '{}&action=2&DMHEIGHT=2000&DMWIDTH=2000&DMSCALE={}'.format(
+                self.get_url_image_info(), scale)
+            self.mapped_data.update({'isShownBy': thumbnail_url})
+
+    def update_mapped_fields(self):
+        ''' To run post mapping. For this one, is_shown_by needs
+        sourceResource/type'''
+        rec_type = self.mapped_data.get('sourceResource',{}).get('type')
+        is_sound_object = False
+        if isinstance(rec_type, basestring):
+            if 'sound' == rec_type.lower():
+                is_sound_object = True
+        else:  # list type
+            for val in rec_type:
+                if 'sound' == val.lower():
+                    is_sound_object = True
+        if not is_sound_object:
+            self.get_larger_preview_image()
+        else:
+            # NOTE: Most contentdm sound objects have bogus placeholder
+            # thumbnails, so don't even bother trying to get any image
+            if 'isShownBy' in self.mapped_data:
+                del self.mapped_data['isShownBy']
+
+
+
+
+
+
+
+
+
+
+    def map_is_shown_at(self) -> Union[str, None]:
+        return self.map_identifier()
+
+    def map_is_shown_by(self) -> Union[str, None]:
+        if not self.is_image_type():
+            return
+
+        url: Union[str, None] = self.map_identifier()
+
+        return f"{url.replace('items', 'thumbs')}?gallery=preview" if url else None
+
+    def map_description(self) -> Union[str, None]:
+        if 'description' not in self.source_metadata:
+            return
+
+        return [d for d in self.source_metadata.get('description') if 'thumbnail' not in d]
+
+    def is_image_type(self) -> bool:
+        if "type" not in self.source_metadata:
+            return False
+
+        type: list[str] = self.source_metadata.get("type", [])
+
+        return type and type[0].lower() == "image"
+
+    def map_identifier(self) -> Union[str, None]:
+        if "identifier" not in self.source_metadata:
+            return
+
+        identifiers = [i for i in self.source_metadata.get('identifier') if "context" not in i]
+        return identifiers[0] if identifiers else None
+
+class ContentdmOaiDcVernacular(OaiVernacular):
+    record_cls = ContentdmOaiDcRecord

--- a/metadata_mapper/mappers/oai/contentdm_oai_dc_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm_oai_dc_mapper.py
@@ -2,9 +2,18 @@ from typing import Union
 import itertools
 import requests
 
-from .oai_mapper import OaiRecord, OaiVernacular, first
+from .oai_mapper import OaiRecord, OaiVernacular, first, last
 
 class ContentdmOaiDcRecord(OaiRecord):
+    def UCLDC_map(self):
+        {
+            "contributor": self.map_contributor(),
+            "creator": self.map_creator(),
+            "spatial": self.map_spatial(),
+            "type": self.map_type(),
+            "language": self.map_language()
+        }
+
     @staticmethod
     def __identifier_match():
         return "cdm/ref"
@@ -19,6 +28,9 @@ class ContentdmOaiDcRecord(OaiRecord):
         Given a list and a match string, returns the first match
         """
         return first(self.get_matches(items, match))
+
+    def get_last_match(self, items: list, match: str):
+        return last(self.get_matches(items, match))
 
     def get_matches(self, items: list, match: str):
         """static
@@ -49,7 +61,7 @@ class ContentdmOaiDcRecord(OaiRecord):
         return [item] if isinstance(item, str) else item
 
     def map_is_shown_at(self):
-        return self.get_first_match(self.source_metadata.get("identifier", self.__identifier_match()))
+        return self.get_last_match(self.source_metadata.get("identifier", self.__identifier_match()))
 
     def map_contributor(self):
         if "contributor" not in self.source_metadata:

--- a/metadata_mapper/mappers/oai/contentdm_oai_dc_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm_oai_dc_mapper.py
@@ -1,154 +1,153 @@
 from typing import Union
+import itertools
+import requests
 
 from .oai_mapper import OaiRecord, OaiVernacular, first
 
 class ContentdmOaiDcRecord(OaiRecord):
     @staticmethod
-    def __identifier_match(self):
+    def __identifier_match():
         return "cdm/ref"
 
-    def get_first_match(self, items: dict, match: str):
+    @staticmethod
+    def __split_string():
+        return ";"
+
+    def get_first_match(self, items: list, match: str):
+        """static
+
+        Given a list and a match string, returns the first match
+        """
         return first(self.get_matches(items, match))
 
-    def get_matches(self, items: dict, match: str):
+    def get_matches(self, items: list, match: str):
+        """static
+
+        Given a ist and a match string, returns those dictionary items containing the string
+        """
         [item for item in items if match in item]
 
-    def map_is_shown_by(self):
-        identifier = self.get_first_match(self.source_metadata.get("identifier", self.__identifier_match()))
-        if not identifier:
-            return
+    def flatten_list(self, items: list):
+        """static
 
-        base_url, i, j, k, collection_id, l, object_id = identifier.rsplit('/', 6)
-        return '/'.join((base_url, 'utils', 'getthumbnail',
-                                  'collection', collection_id, 'id', object_id))
+        Given a list, flattens and strips the list items
+        """
+        return list([s.strip() for s in itertools.chain.from_iterable(items)])
 
+    def split_and_flatten(self, items: list, split: str):
+        """static
+
+        Given a list of strings or nested lists, splits the values on the split string then flattens
+        """
+        return self.flatten_list([c.split(split) for c in filter(None, items)])
+
+    def ensure_list(self, item: Union[str, list]):
+        """static
+
+        Given a list or string, ensures we have a list
+        """
+        return [item] if isinstance(item, str) else item
 
     def map_is_shown_at(self):
-        return self.get_first_match(self.source_metadata.get("identifier", self._ident_match))
-
-    """This is where we're at"""
-
+        return self.get_first_match(self.source_metadata.get("identifier", self.__identifier_match()))
 
     def map_contributor(self):
-        self.to_source_resource_with_split('contributor', 'contributor')
+        if "contributor" not in self.source_metadata:
+            return
+
+        return self.split_and_flatten(self.ensure_list(self.source_metadata.get("contributor")), self.__split_string())
 
     def map_creator(self):
-        self.to_source_resource_with_split('creator', 'creator')
+        if "creator" not in self.source_metadata:
+            return
+
+        return self.split_and_flatten(self.ensure_list(self.source_metadata.get("creator")), self.__split_string())
 
     def map_subject(self):
-        values = self.split_values('subject')
-        subject_objs = [{'name': v} for v in values]
-        self.update_source_resource({'subject': subject_objs})
+        if "subject" not in self.source_metadata:
+            return
+
+        values = self.split_and_flatten(self.ensure_list(self.source_metadata.get("subject")), self.__split_string())
+        return [{'name': v} for v in values]
 
     def map_spatial(self):
-        fields = ('coverage', 'spatial')
-        self.source_resource_orig_list_to_prop_with_split(fields, 'spatial')
+        values = self.source_metadata_values(["coverage", "spatial"])
+        if not values:
+            return
+
+        return self.split_and_flatten(values)
 
     def map_type(self):
-        '''TODO:Funky, but map_type comes after the is_shown_by, should change order
-        '''
-        self.to_source_resource_with_split('type', 'type')
+        return self.split_and_flatten(self.source_metadata.get("type"), self.__split_string())
 
     def map_language(self):
-        self.to_source_resource_with_split('language', 'language')
+        return self.split_and_flatten(self.source_metadata.get("language"), self.__split_string())
 
-    def get_url_image_info(self):
-        image_info = {'height': 0, 'width': 0}
-        ident = self.get_identifier_match('cdm/ref')
-        base_url, i, j, k, collid, l, objid = ident.rsplit('/', 6)
-        # url_image_info give json data about image for record
-        url_image_info = '/'.join((base_url, 'utils', 'ajaxhelper'))
-        url_image_info = '{}?CISOROOT={}&CISOPTR={}'.format(url_image_info,
-                                                            collid, objid)
-        logger.error(url_image_info)
-        return url_image_info
+    def map_is_shown_by(self):
+        """
+        This was originally a "post-map" function. but really, this is seems like it should be map_is_shown_by()
+
+        Comment from calisphere function:
+        To run post mapping. For this one, is_shown_by needs
+        sourceResource/type"""
+        record_type = self.map_type()
+        if "sound" in [t.lower() for t in self.ensure_list(record_type)]:
+            return None
+
+        return self.get_preview_image_url()
+
+    def get_preview_image_url(self):
+        """
+        see get_larger_preview_image(), below, as it is mapped to isShownBy as well
+
+        """
+        larger_preview_image = self.get_larger_preview_image_url()
+        if larger_preview_image:
+            return larger_preview_image
+
+        parts = self.get_identifier_parts()
+        return '/'.join((parts["base_url"], 'utils', 'getthumbnail',
+                         'collection', parts["collection_id"], 'id', parts["object_id"]))
+
+    def get_larger_preview_image_url(self):
+        image_info = self.get_image_info()
+        if not image_info['height'] > 0:
+            return
+
+        max_dim = 1024.0
+        if image_info['height'] >= image_info['width']:
+            scale = int((max_dim / image_info['height']) * 100)
+        else:
+            scale = int((max_dim / image_info['width']) * 100)
+        scale = 100 if scale > 100 else scale
+        return '{}&action=2&DMHEIGHT=2000&DMWIDTH=2000&DMSCALE={}'.format(self.get_url_image_info(), scale)
 
     def get_image_info(self):
-        '''Return image info for the contentdm object'''
+        """
+        This seems wrong, shouldn't an enrichment handle image-related tasks?
+        """
         image_info = {'height': 0, 'width': 0}
-        ident = self.get_identifier_match('cdm/ref')
-        if ident:
-            image_info = requests.get(self.get_url_image_info()).json()[
-                'imageinfo']
-        return image_info
+        identifier = self.get_first_match(self.source_metadata.get("identifier", self.__identifier_match()))
+        if not identifier:
+            return image_info
 
-    def get_larger_preview_image(self):
-        # Try to get a bigger image than the thumbnail.
-        # Some "text" types have a large image
-        image_info = self.get_image_info()
-        if image_info['height'] > 0:  # if 0 only thumb available
-            # figure scaling
-            max_dim = 1024.0
-            scale = 100
-            if image_info['height'] >= image_info['width']:
-                scale = int((max_dim / image_info['height']) * 100)
-            else:
-                scale = int((max_dim / image_info['width']) * 100)
-            scale = 100 if scale > 100 else scale
-            thumbnail_url = '{}&action=2&DMHEIGHT=2000&DMWIDTH=2000&DMSCALE={}'.format(
-                self.get_url_image_info(), scale)
-            self.mapped_data.update({'isShownBy': thumbnail_url})
+        response = requests.get(self.get_url_image_info()).json()['imageinfo']
+        return response if response else image_info
 
-    def update_mapped_fields(self):
-        ''' To run post mapping. For this one, is_shown_by needs
-        sourceResource/type'''
-        rec_type = self.mapped_data.get('sourceResource',{}).get('type')
-        is_sound_object = False
-        if isinstance(rec_type, basestring):
-            if 'sound' == rec_type.lower():
-                is_sound_object = True
-        else:  # list type
-            for val in rec_type:
-                if 'sound' == val.lower():
-                    is_sound_object = True
-        if not is_sound_object:
-            self.get_larger_preview_image()
-        else:
-            # NOTE: Most contentdm sound objects have bogus placeholder
-            # thumbnails, so don't even bother trying to get any image
-            if 'isShownBy' in self.mapped_data:
-                del self.mapped_data['isShownBy']
+    def get_url_image_info(self):
+        parts = self.get_identifier_parts()
+        url_image_info = '/'.join((parts["base_url"], 'utils', 'ajaxhelper'))
+        return '{}?CISOROOT={}&CISOPTR={}'.format(url_image_info, parts["collection_id"], parts["object_id"])
 
+    def get_identifier_parts(self):
+        identifier = self.get_first_match(self.source_metadata.get("identifier", self.__identifier_match()))
+        base_url, _, _, _, collection_id, _, object_id = identifier.rsplit('/', 6)
+        return {
+            "base_url": base_url,
+            "collection_id": collection_id,
+            "object_id": object_id
+        }
 
-
-
-
-
-
-
-
-
-    def map_is_shown_at(self) -> Union[str, None]:
-        return self.map_identifier()
-
-    def map_is_shown_by(self) -> Union[str, None]:
-        if not self.is_image_type():
-            return
-
-        url: Union[str, None] = self.map_identifier()
-
-        return f"{url.replace('items', 'thumbs')}?gallery=preview" if url else None
-
-    def map_description(self) -> Union[str, None]:
-        if 'description' not in self.source_metadata:
-            return
-
-        return [d for d in self.source_metadata.get('description') if 'thumbnail' not in d]
-
-    def is_image_type(self) -> bool:
-        if "type" not in self.source_metadata:
-            return False
-
-        type: list[str] = self.source_metadata.get("type", [])
-
-        return type and type[0].lower() == "image"
-
-    def map_identifier(self) -> Union[str, None]:
-        if "identifier" not in self.source_metadata:
-            return
-
-        identifiers = [i for i in self.source_metadata.get('identifier') if "context" not in i]
-        return identifiers[0] if identifiers else None
 
 class ContentdmOaiDcVernacular(OaiVernacular):
     record_cls = ContentdmOaiDcRecord

--- a/metadata_mapper/mappers/oai/oai_mapper.py
+++ b/metadata_mapper/mappers/oai/oai_mapper.py
@@ -5,7 +5,7 @@ from typing import Union
 from lxml import etree
 from sickle import models
 
-from ..mapper import Record, Vernacular, collate_values
+from ..mapper import Record, Vernacular, collate_values, first
 
 
 class OaiRecord(Record):

--- a/metadata_mapper/mappers/oai/oai_mapper.py
+++ b/metadata_mapper/mappers/oai/oai_mapper.py
@@ -5,7 +5,7 @@ from typing import Union
 from lxml import etree
 from sickle import models
 
-from ..mapper import Record, Vernacular, collate_values, first
+from ..mapper import Record, Vernacular, collate_values, first, last
 
 
 class OaiRecord(Record):

--- a/metadata_mapper/mappers/oai/oai_mapper.py
+++ b/metadata_mapper/mappers/oai/oai_mapper.py
@@ -5,7 +5,7 @@ from typing import Union
 from lxml import etree
 from sickle import models
 
-from ..mapper import Record, Vernacular
+from ..mapper import Record, Vernacular, collate_values
 
 
 class OaiRecord(Record):
@@ -15,7 +15,7 @@ class OaiRecord(Record):
         return {
             'contributor': self.source_metadata.get('contributor'),
             'creator': self.source_metadata.get('creator'),
-            'date': self.collate_values(
+            'date': collate_values(
                 self.source_metadata_values(
                     'available',
                     'created',
@@ -28,15 +28,15 @@ class OaiRecord(Record):
                     'valid'
                 )
             ),
-            'description': self.collate_values(
+            'description': collate_values(
                 self.source_metadata_values('abstract', 'description', 'tableOfContents')
             ),
             'extent': self.source_metadata.get('extent'),
-            'format': self.collate_values(self.source_metadata_values('format', 'medium')),
-            'identifier': self.collate_values(self.source_metadata_values('bibliographicCitation', 'identifier')),
+            'format': collate_values(self.source_metadata_values('format', 'medium')),
+            'identifier': collate_values(self.source_metadata_values('bibliographicCitation', 'identifier')),
             'provenance': self.source_metadata.get('provenance'),
             'publisher': self.source_metadata.get('publisher'),
-            'relation': self.collate_values(
+            'relation': collate_values(
                 self.source_metadata_values(
                     'conformsTo',
                     'hasFormat',
@@ -54,8 +54,8 @@ class OaiRecord(Record):
                     'require'
                 )
             ),
-            'rights': self.collate_values(self.source_metadata_values('accessRights', 'rights')),
-            'spatial': self.collate_values(self.source_metadata_values('coverage', 'spatial')),
+            'rights': collate_values(self.source_metadata_values('accessRights', 'rights')),
+            'spatial': collate_values(self.source_metadata_values('coverage', 'spatial')),
             'subject': self.map_subject(),
             'temporal': self.source_metadata.get('temporal'),
             'title': self.source_metadata.get('title'),


### PR DESCRIPTION
The Calisphere mapper that we're using as a starting place does some things that other mappers we've implemented haven't done: multiple "passes" on the data, dependence on mapped values and, perhaps most egregious: makes an HTTP request to fetch information about an image. The first two issues won't be a problem, and we can do the request, although I do wonder if the mapper is the right spot for this, not because I necessarily think is isn't, so much as I don't know if there's a more appropriate place for this. Perhaps the fetching process should include fetching related URLs so that the mapper can be supplied with everything it needs in advance. Alternative, perhaps an enrichment that fetches and appropriately handles responses should be the way to tackle this, again, to keep the mapper itself operating solely on the source metadata.