### PR TITLE
1. Implement first round of contentdm mappers

### DIFF
--- a/metadata_fetcher/settings.py
+++ b/metadata_fetcher/settings.py
@@ -1,5 +1,9 @@
 import os
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 LOCAL_RUN = os.environ.get('FETCHER_LOCAL_RUN', False)
 DATA_DEST = os.environ.get('FETCHER_DATA_DEST', 's3')
 LOG_LEVEL = os.environ.get('LOG_LEVEL', 'DEBUG')    # doesn't currently do anything

--- a/metadata_mapper/lambda_function.py
+++ b/metadata_mapper/lambda_function.py
@@ -17,10 +17,10 @@ def import_vernacular_reader(mapper_type):
     nuxeo       | nuxeo_mapper        | NuxeoVernacular
     content_dm  | content_dm_mapper   | ContentDmVernacular
     """
-    mapper_parent_modules, snake_cased_mapper_name = mapper_type.split(".")
+    *mapper_parent_modules, snake_cased_mapper_name = mapper_type.split(".")
 
     mapper_module = importlib.import_module(
-        f"mappers.{mapper_parent_modules}.{snake_cased_mapper_name}_mapper",
+        f"mappers.{'.'.join(mapper_parent_modules)}.{snake_cased_mapper_name}_mapper",
         package="metadata_mapper"
     )
 

--- a/metadata_mapper/map_registry_collections.py
+++ b/metadata_mapper/map_registry_collections.py
@@ -21,6 +21,13 @@ def map_endpoint(url):
         'yosemite_oai_dc': 'oai.yosemite',
         'up_oai_dc': 'oai.up',
         'ucsc_oai_dpla': 'oai.samvera',
+        'contentdm_oai_dc': 'oai.contentdm',
+        'arck_oai': 'oai.contentdm.arck',
+        'black_gold_oai': 'oai.contentdm.blackgold',
+        'chico_oai_dc': 'oai.contentdm.chico',
+        'chula_vista_pl_contentdm_oai_dc': 'oai.contentdm.cvpl',
+        'contentdm_oai_dc_get_sound_thumbs': 'oai.contentdm.pepperdine',
+        'csudh_contentdm_oai_dc': 'oai.contentdm.csudh'
     }
 
     collection_page = url

--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -3,6 +3,7 @@ import json
 import re
 import boto3
 import hashlib
+import itertools
 
 from abc import ABC
 from markupsafe import Markup
@@ -73,6 +74,7 @@ class Vernacular(ABC, object):
 class Record(ABC, object):
 
     def __init__(self, collection_id: int, record: dict[str, Any]):
+        self.mapped_data = None
         self.collection_id: int = collection_id
         self.source_metadata: dict = record
         # TODO: pre_mapped_data is a stop gap to accomodate
@@ -140,6 +142,20 @@ class Record(ABC, object):
             return value
         if isinstance(value, list):
             return value[0]
+
+    def split_and_flatten(self, field):
+        """
+        Given a list of strings or nested lists, splits the values on the split string then flattens
+        """
+        values = self.source_metadata.get(field)
+
+        if not values:
+            return
+
+        split_values = [c.split(';') for c in filter(None, values)]
+
+        return list([s.strip() for s in itertools.chain.from_iterable(split_values)])
+
 
     # Enrichments
     # The enrichment chain is a dpla construction that we are porting to Rikolti

--- a/metadata_mapper/mappers/oai/contentdm/arck_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/arck_mapper.py
@@ -2,6 +2,10 @@ from ..contentdm_mapper import ContentdmRecord, ContentdmVernacular
 
 
 class ArckRecord(ContentdmRecord):
+    """
+    TODO: Analysis of the 11 collections to see if the `map_is_shown_by()` logic can be simplified.
+    """
+
     identifier_match = "view/ARCK3D"
 
     def UCLDC_map(self):
@@ -21,7 +25,7 @@ class ArckRecord(ContentdmRecord):
         return candidates[-1]
 
     def map_relation(self):
-        if self.map_is_shown_at():
+        if self.map_is_shown_by():
             return
 
         return self.source_metadata.get("relation")

--- a/metadata_mapper/mappers/oai/contentdm/arck_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/arck_mapper.py
@@ -1,0 +1,32 @@
+from .contentdm_mapper import ContentdmRecord, ContentdmVernacular
+
+class ArckRecord(ContentdmRecord):
+    @staticmethod
+    def identifier_match():
+        return ["view/ARCK3D"]
+
+    def UCLDC_map(self):
+        {
+            "source": self.source_metadata.get("source")
+        }
+
+    def map_is_shown_by(self):
+        values = self.source_metadata.get("relation")
+        if not values:
+            return
+
+        candidates = [v for v in values if "/thumbnail" in v]
+        if not candidates:
+            return
+
+        return candidates[-1]
+
+    def map_relation(self):
+        if self.map_is_shown_at():
+            return
+
+        return self.source_metadata.get("relation")
+
+
+class ArckVernacular(ContentdmVernacular):
+    record_cls = ArckRecord

--- a/metadata_mapper/mappers/oai/contentdm/arck_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/arck_mapper.py
@@ -1,4 +1,4 @@
-from .contentdm_mapper import ContentdmRecord, ContentdmVernacular
+from ..contentdm_mapper import ContentdmRecord, ContentdmVernacular
 
 class ArckRecord(ContentdmRecord):
     @staticmethod
@@ -6,7 +6,7 @@ class ArckRecord(ContentdmRecord):
         return ["view/ARCK3D"]
 
     def UCLDC_map(self):
-        {
+        return {
             "source": self.source_metadata.get("source")
         }
 

--- a/metadata_mapper/mappers/oai/contentdm/arck_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/arck_mapper.py
@@ -1,9 +1,8 @@
 from ..contentdm_mapper import ContentdmRecord, ContentdmVernacular
 
+
 class ArckRecord(ContentdmRecord):
-    @staticmethod
-    def identifier_match():
-        return ["view/ARCK3D"]
+    identifier_match = "view/ARCK3D"
 
     def UCLDC_map(self):
         return {

--- a/metadata_mapper/mappers/oai/contentdm/blackgold_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/blackgold_mapper.py
@@ -1,0 +1,23 @@
+from .contentdm_mapper import ContentdmRecord, ContentdmVernacular
+
+
+class BlackgoldRecord(ContentdmRecord):
+    """Appears to map ok"""
+    @staticmethod
+    def identifier_match():
+        return ["luna/servlet/detail"]
+
+    def map_is_shown_by(self):
+        values = self.source_metadata.get("identifier")
+        if not values:
+            return
+
+        candidates = [v for v in values if "mediafile=" in v]
+        if not candidates:
+            return
+
+        return candidates[-1].replace("Size2", "Size4")
+
+
+class BlackgoldVernacular(ContentdmVernacular):
+    record_cls = BlackgoldRecord

--- a/metadata_mapper/mappers/oai/contentdm/blackgold_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/blackgold_mapper.py
@@ -2,10 +2,7 @@ from .contentdm_mapper import ContentdmRecord, ContentdmVernacular
 
 
 class BlackgoldRecord(ContentdmRecord):
-    """Appears to map ok"""
-    @staticmethod
-    def identifier_match():
-        return ["luna/servlet/detail"]
+    identifier_match = "luna/servlet/detail"
 
     def map_is_shown_by(self):
         values = self.source_metadata.get("identifier")

--- a/metadata_mapper/mappers/oai/contentdm/chico_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/chico_mapper.py
@@ -1,0 +1,26 @@
+from .contentdm_mapper import ContentdmRecord, ContentdmVernacular
+
+
+class ChicoRecord(ContentdmRecord):
+    def UCLDC_map(self):
+        """Removing `created`, see:
+        https://github.com/calisphere-legacy-harvester/dpla-ingestion/blob/ucldc/lib/mappers/chico_oai_mapper.py
+        """
+        return {
+            'date': self.collate_fields(
+                [
+                    'available',
+                    'date',
+                    'dateAccepted',
+                    'dateCopyrighted',
+                    'dateSubmitted',
+                    'issued',
+                    'modified',
+                    'valid'
+                ]
+            )
+        }
+
+
+class ChicoVernacular(ContentdmVernacular):
+    record_cls = ChicoRecord

--- a/metadata_mapper/mappers/oai/contentdm/chico_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/chico_mapper.py
@@ -1,4 +1,4 @@
-from .contentdm_mapper import ContentdmRecord, ContentdmVernacular
+from ..contentdm_mapper import ContentdmRecord, ContentdmVernacular
 
 
 class ChicoRecord(ContentdmRecord):

--- a/metadata_mapper/mappers/oai/contentdm/cvpl_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/cvpl_mapper.py
@@ -2,9 +2,7 @@ from ..contentdm_mapper import ContentdmRecord, ContentdmVernacular
 
 
 class CvplRecord(ContentdmRecord):
-    @staticmethod
-    def identifier_match():
-        return ["//archives.chulavistalibrary.com"]
+    identifier_match = "//archives.chulavistalibrary.com"
 
     def get_larger_preview_image_url(self):
         identifier = self.get_matching_identifier(last=True)

--- a/metadata_mapper/mappers/oai/contentdm/cvpl_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/cvpl_mapper.py
@@ -1,4 +1,4 @@
-from .contentdm_mapper import ContentdmRecord, ContentdmVernacular
+from ..contentdm_mapper import ContentdmRecord, ContentdmVernacular
 
 
 class CvplRecord(ContentdmRecord):

--- a/metadata_mapper/mappers/oai/contentdm/cvpl_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/cvpl_mapper.py
@@ -11,9 +11,7 @@ class CvplRecord(ContentdmRecord):
 
         base_url, _, collection_comma_object = identifier.rsplit('/', 2)
         collection_id, object_id = collection_comma_object.split(',')
-        return ''.join((base_url, '/cgi-bin',
-                        '/getimage.exe?DMSCALE=20&CISOROOT=/', collection_id,
-                        '&CISOPTR=', object_id))
+        return f"{base_url}/cgi-bin/getimage.exe?DMSCALE=20&CISOROOT=/{collection_id}&CISOPTR={object_id}"
 
     def map_is_shown_at(self):
         return self.get_matching_identifier(last=True)

--- a/metadata_mapper/mappers/oai/contentdm/cvpl_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/cvpl_mapper.py
@@ -1,0 +1,25 @@
+from .contentdm_mapper import ContentdmRecord, ContentdmVernacular
+
+
+class CvplRecord(ContentdmRecord):
+    @staticmethod
+    def identifier_match():
+        return ["//archives.chulavistalibrary.com"]
+
+    def get_larger_preview_image_url(self):
+        identifier = self.get_matching_identifier(last=True)
+        if not identifier:
+            return
+
+        base_url, _, collection_comma_object = identifier.rsplit('/', 2)
+        collection_id, object_id = collection_comma_object.split(',')
+        return ''.join((base_url, '/cgi-bin',
+                        '/getimage.exe?DMSCALE=20&CISOROOT=/', collection_id,
+                        '&CISOPTR=', object_id))
+
+    def map_is_shown_at(self):
+        return self.get_matching_identifier(last=True)
+
+
+class CvplVernacular(ContentdmVernacular):
+    record_cls = CvplRecord

--- a/metadata_mapper/mappers/oai/contentdm_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm_mapper.py
@@ -67,8 +67,7 @@ class ContentdmRecord(OaiRecord):
             return larger_preview_image
 
         parts = self.get_identifier_parts()
-        return '/'.join((parts["base_url"], 'utils', 'getthumbnail',
-                         'collection', parts["collection_id"], 'id', parts["object_id"]))
+        return f"{parts['base_url']}/utils/getthumbnail/collection/{parts['collection_id']}/id/{parts['object_id']}"
 
     def get_larger_preview_image_url(self):
         image_info = self.get_image_info()
@@ -81,7 +80,7 @@ class ContentdmRecord(OaiRecord):
         else:
             scale = int((max_dim / image_info['width']) * 100)
         scale = 100 if scale > 100 else scale
-        return '{}&action=2&DMHEIGHT=2000&DMWIDTH=2000&DMSCALE={}'.format(self.get_url_image_info(), scale)
+        return f"{self.get_url_image_info()}&action=2&DMHEIGHT=2000&DMWIDTH=2000&DMSCALE={scale}"
 
     def get_image_info(self):
         """
@@ -101,7 +100,7 @@ class ContentdmRecord(OaiRecord):
             return
 
         url_image_info = '/'.join((parts["base_url"], 'utils', 'ajaxhelper'))
-        return '{}?CISOROOT={}&CISOPTR={}'.format(url_image_info, parts["collection_id"], parts["object_id"])
+        return f"{url_image_info}?CISOROOT={parts['collection_id']}&CISOPTR={parts['object_id']}"
 
     def get_identifier_parts(self):
         identifier = self.get_matching_identifier()

--- a/metadata_mapper/mappers/oai/contentdm_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm_mapper.py
@@ -84,7 +84,7 @@ class ContentdmRecord(OaiRecord):
 
     def get_image_info(self):
         """
-        TODO: address HTTP request taking place in here
+        TODO: for Amy or Barbara: alternative strategy for making another request
         """
         image_info = {'height': 0, 'width': 0}
         identifier = self.get_matching_identifier()

--- a/metadata_mapper/mappers/oai/contentdm_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm_mapper.py
@@ -5,6 +5,8 @@ from .oai_mapper import OaiRecord, OaiVernacular
 
 
 class ContentdmRecord(OaiRecord):
+    identifier_match = "cdm/ref"
+
     def UCLDC_map(self):
         return {
             "contributor": self.split_and_flatten('contributor'),
@@ -14,10 +16,6 @@ class ContentdmRecord(OaiRecord):
             "language": self.split_and_flatten('language'),
             "subject": self.map_subject()
         }
-
-    @staticmethod
-    def identifier_match():
-        return ["cdm/ref"]
 
     def map_is_shown_at(self):
         return self.get_matching_identifier(last=True)
@@ -120,7 +118,7 @@ class ContentdmRecord(OaiRecord):
     def get_matching_identifier(self, last=False):
         """Gets a matching identifier, defaults to the first one, pass last=True to get the last one"""
         identifiers = [i for i in self.source_metadata.get("identifier", [])
-                       if all([m in i for m in self.identifier_match()])]
+                       if self.identifier_match in i]
         if not identifiers:
             return
 

--- a/metadata_mapper/mappers/oai/contentdm_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm_mapper.py
@@ -1,0 +1,126 @@
+import requests
+import itertools
+
+from .oai_mapper import OaiRecord, OaiVernacular
+
+
+class ContentdmRecord(OaiRecord):
+    def UCLDC_map(self):
+        return {
+            "contributor": self.split_and_flatten('contributor'),
+            "creator": self.split_and_flatten('creator'),
+            "spatial": self.map_spatial(),
+            "type": self.map_type(),
+            "language": self.split_and_flatten('language'),
+            "subject": [{'name': v} for v in self.split_and_flatten('subject')]
+        }
+
+    @staticmethod
+    def identifier_match():
+        return ["cdm/ref"]
+
+    def map_is_shown_at(self):
+        return self.get_matching_identifier(last=True)
+
+    def map_is_shown_by(self):
+        """
+        This was originally a "post-map" function. but really, this is seems like it should be map_is_shown_by()
+
+        Comment from calisphere function:
+        To run post mapping. For this one, is_shown_by needs sourceResource/type
+        """
+        record_type = self.map_type()
+        if not record_type:
+            return
+
+        record_type_list = [record_type] if isinstance(record_type, str) else record_type
+
+        if "sound" in [t.lower() for t in record_type_list]:
+            return None
+
+        return self.get_preview_image_url()
+
+    def map_type(self):
+        """Used by map_is_shown_by() in this class, so cannot be directly added to the mapping"""
+        return self.split_and_flatten('type')
+
+    def map_spatial(self):
+        values = [v for v in self.collate_fields(["coverage", "spatial"]) if v]
+        if not values:
+            return
+
+        split_values = [c.split(';') for c in filter(None, values)]
+
+        return list([s.strip() for s in itertools.chain.from_iterable(split_values)])
+
+    def get_preview_image_url(self):
+        """
+        see get_larger_preview_image(), below, as it is mapped to isShownBy as well
+        """
+        larger_preview_image = self.get_larger_preview_image_url()
+        if larger_preview_image:
+            return larger_preview_image
+
+        parts = self.get_identifier_parts()
+        return '/'.join((parts["base_url"], 'utils', 'getthumbnail',
+                         'collection', parts["collection_id"], 'id', parts["object_id"]))
+
+    def get_larger_preview_image_url(self):
+        image_info = self.get_image_info()
+        if not image_info['height'] > 0:
+            return
+
+        max_dim = 1024.0
+        if image_info['height'] >= image_info['width']:
+            scale = int((max_dim / image_info['height']) * 100)
+        else:
+            scale = int((max_dim / image_info['width']) * 100)
+        scale = 100 if scale > 100 else scale
+        return '{}&action=2&DMHEIGHT=2000&DMWIDTH=2000&DMSCALE={}'.format(self.get_url_image_info(), scale)
+
+    def get_image_info(self):
+        """
+        TODO: address HTTP request taking place in here
+        """
+        image_info = {'height': 0, 'width': 0}
+        identifier = self.get_matching_identifier()
+        if not identifier:
+            return image_info
+
+        response = requests.get(self.get_url_image_info()).json()['imageinfo']
+        return response if response else image_info
+
+    def get_url_image_info(self):
+        parts = self.get_identifier_parts()
+        if not parts:
+            return
+
+        url_image_info = '/'.join((parts["base_url"], 'utils', 'ajaxhelper'))
+        return '{}?CISOROOT={}&CISOPTR={}'.format(url_image_info, parts["collection_id"], parts["object_id"])
+
+    def get_identifier_parts(self):
+        identifier = self.get_matching_identifier()
+        if not identifier:
+            return
+
+        base_url, _, _, _, collection_id, _, object_id = identifier.rsplit('/', 6)
+        return {
+            "base_url": base_url,
+            "collection_id": collection_id,
+            "object_id": object_id
+        }
+
+    def get_matching_identifier(self, last=False):
+        """Gets a matching identifier, defaults to the first one, pass last=True to get the last one"""
+        identifiers = [i for i in self.source_metadata.get("identifier")
+                       if all([m in i for m in self.identifier_match()])]
+        if not identifiers:
+            return
+
+        if last:
+            return identifiers[-1]
+        return identifiers[0]
+
+
+class ContentdmVernacular(OaiVernacular):
+    record_cls = ContentdmRecord

--- a/metadata_mapper/mappers/oai/contentdm_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm_mapper.py
@@ -12,7 +12,7 @@ class ContentdmRecord(OaiRecord):
             "spatial": self.map_spatial(),
             "type": self.map_type(),
             "language": self.split_and_flatten('language'),
-            "subject": [{'name': v} for v in self.split_and_flatten('subject')]
+            "subject": self.map_subject()
         }
 
     @staticmethod
@@ -52,6 +52,13 @@ class ContentdmRecord(OaiRecord):
         split_values = [c.split(';') for c in filter(None, values)]
 
         return list([s.strip() for s in itertools.chain.from_iterable(split_values)])
+
+    def map_subject(self):
+        subject = self.source_metadata.get('subject')
+        if not subject:
+            return
+
+        return [{'name': v} for v in self.split_and_flatten('subject')]
 
     def get_preview_image_url(self):
         """
@@ -112,7 +119,7 @@ class ContentdmRecord(OaiRecord):
 
     def get_matching_identifier(self, last=False):
         """Gets a matching identifier, defaults to the first one, pass last=True to get the last one"""
-        identifiers = [i for i in self.source_metadata.get("identifier")
+        identifiers = [i for i in self.source_metadata.get("identifier", [])
                        if all([m in i for m in self.identifier_match()])]
         if not identifiers:
             return


### PR DESCRIPTION
This follows https://github.com/ucldc/rikolti/pull/313. It includes everyone's favorite method with a universally disliked name: `split_and_flatten()`. Let's decide what to call it.

It includes:

- oai.contentdm
- oai.contentdm.cvpl
- oai.contentdm.chico
- oai.contentdm.arck
- oai.contentdm.blackgold