### PR TITLE
2. Simplify Arck mapper, allow mapping to Callables in the process

### DIFF
--- a/metadata_mapper/__init__.py
+++ b/metadata_mapper/__init__.py
@@ -1,0 +1,1 @@
+import utilities

--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -17,6 +17,8 @@ from .iso639_1 import iso_639_1
 from .iso639_3 import iso_639_3, language_regexes, wb_language_regexes
 from typing import Callable
 
+from utilities import returns_callable
+
 
 class UCLDCWriter(object):
     def __init__(self, payload):
@@ -81,6 +83,7 @@ class Vernacular(ABC, object):
         return False
 
 
+
 class Record(ABC, object):
 
     def __init__(self, collection_id: int, record: dict[str, Any]):
@@ -113,6 +116,7 @@ class Record(ABC, object):
             mapped_data = {**mapped_data, **supermap}
         mapped_data = {**mapped_data, **self.UCLDC_map()}
 
+
         # Mapped value may be a function or lambda
         self.mapped_data = {k: v() if isinstance(v, Callable) else v for (k, v)
                             in mapped_data.items()}
@@ -130,9 +134,11 @@ class Record(ABC, object):
         return {}
 
     # Mapper Helpers
+    @returns_callable
     def collate_subfield(self, field, subfield):
         return [f[subfield] for f in self.source_metadata.get(field, [])]
 
+    @returns_callable
     def collate_fields(self, fieldlist):
         ''' collate multiple field values into a single list '''
         collated = []
@@ -146,6 +152,7 @@ class Record(ABC, object):
 
         return collated
 
+    @returns_callable
     def first_string_in_field(self, field):
         """
         Fetches a field value from source_metadata, and returns it if it's a string, or the first
@@ -157,6 +164,7 @@ class Record(ABC, object):
         if isinstance(value, list):
             return value[0]
 
+    @returns_callable
     def split_and_flatten(self, field):
         """
         Given a list of strings or nested lists, splits the values on the split string then flattens

--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -304,13 +304,13 @@ class Record(ABC, object):
                 self.mapped_data[field] += (field_value)
             else:
                 self.mapped_data[field] = field_value
-        else:   # default is fill if empty
+        else:  # default is fill if empty
             if field not in self.mapped_data:
                 self.mapped_data[field] = field_value
 
         # not sure what this is about
         # if not exists(data, "@context"):
-            # self.mapped_data["@context"] = "http://dp.la/api/items/context"
+        # self.mapped_data["@context"] = "http://dp.la/api/items/context"
         return self
 
     def shred(self, prop, delim=";"):
@@ -331,7 +331,7 @@ class Record(ABC, object):
         1,021 times:    prop=["sourceResource/type"]
         5 times:        prop=["sourceResource/description"],   delim=["<br>"]
         """
-        field = prop[0].split('/')[1:][0]     # remove sourceResource
+        field = prop[0].split('/')[1:][0]  # remove sourceResource
         delim = delim[0]
 
         # TODO: this is a way to get around cases where a key with name <field>
@@ -417,8 +417,8 @@ class Record(ABC, object):
         src_val = self.mapped_data.get(src)
         dest_val = self.mapped_data.get(dest, [])
         if (
-              (not (isinstance(src_val, list) or isinstance(src_val, str))) or
-              (not (isinstance(dest_val, list) or isinstance(dest_val, str)))
+                (not (isinstance(src_val, list) or isinstance(src_val, str))) or
+                (not (isinstance(dest_val, list) or isinstance(dest_val, str)))
         ):
             self.enrichment_report.append(
                 f"[copy_prop]: Prop {src} is {type(src_val)} and prop {dest} "
@@ -445,7 +445,7 @@ class Record(ABC, object):
         # 2079 times: prop=["sourceResource/subject"]
         # 2079 times: prop=["sourceResource/spatial"]
         """
-        src = prop[0].split('/')[-1]   # remove sourceResource
+        src = prop[0].split('/')[-1]  # remove sourceResource
         # TODO: this is a way to get around cases where a key with name <src>
         # is present in self.mapped_data, but the value is None. Should get rid
         # of None value keys in self.mapped_data
@@ -1159,7 +1159,7 @@ class Record(ABC, object):
 
         for field in default_fields + dont_strip_trailing_dot:
             # TODO: this won't work for deeply nested fields
-            field.split('/')[1]     # remove sourceResource
+            field.split('/')[1]  # remove sourceResource
 
             if field not in self.mapped_data:
                 continue
@@ -1248,8 +1248,8 @@ class Record(ABC, object):
     def solr_updater(self):
 
         def normalize_sort_field(sort_field,
-                                default_missing='~title unknown',
-                                missing_equivalents=['title unknown']):
+                                 default_missing='~title unknown',
+                                 missing_equivalents=['title unknown']):
             sort_field = sort_field.lower()
             # remove punctuation
             re_alphanumspace = re.compile(r'[^0-9A-Za-z\s]*')
@@ -1403,8 +1403,8 @@ class Record(ABC, object):
             '''
             ark = None
             id_fields = ("mods_recordInfo_recordIdentifier_mlt",
-                        "mods_recordInfo_recordIdentifier_s",
-                        "mods_recordInfo_recordIdentifier_t")
+                         "mods_recordInfo_recordIdentifier_s",
+                         "mods_recordInfo_recordIdentifier_t")
             for f in id_fields:
                 try:
                     mangled_ark = doc['originalRecord'][f]
@@ -1555,7 +1555,7 @@ class Record(ABC, object):
                 solr_doc['campus_url'] = [c['id'] for c in campuses]
                 solr_doc['campus_name'] = [c['name'] for c in campuses]
                 solr_doc['campus_data'] = [f"{c['id']}::{c['name']}"
-                                            for c in campuses]
+                                           for c in campuses]
 
             if record.get('object_dimensions'):
                 solr_doc['reference_image_dimensions'] = (

--- a/metadata_mapper/mappers/oai/chapman_mapper.py
+++ b/metadata_mapper/mappers/oai/chapman_mapper.py
@@ -11,8 +11,8 @@ class ChapmanRecord(OaiRecord):
 
     def UCLDC_map(self):
         return {
-            'description': self.map_description(),
-            'identifier': self.map_identifier()
+            'description': self.map_description,
+            'identifier': self.map_identifier
         }
 
     def map_is_shown_at(self) -> Union[str, None]:

--- a/metadata_mapper/mappers/oai/contentdm/arck_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/arck_mapper.py
@@ -2,33 +2,14 @@ from ..contentdm_mapper import ContentdmRecord, ContentdmVernacular
 
 
 class ArckRecord(ContentdmRecord):
-    """
-    TODO: Analysis of the 11 collections to see if the `map_is_shown_by()` logic can be simplified.
-    """
-
     identifier_match = "view/ARCK3D"
 
     def UCLDC_map(self):
         return {
-            "source": self.source_metadata.get("source")
+            "source": self.source_metadata.get("source"),
+            "isShownBy": self.source_metadata.get("relation"),
+            "relation": ""
         }
-
-    def map_is_shown_by(self):
-        values = self.source_metadata.get("relation")
-        if not values:
-            return
-
-        candidates = [v for v in values if "/thumbnail" in v]
-        if not candidates:
-            return
-
-        return candidates[-1]
-
-    def map_relation(self):
-        if self.map_is_shown_by():
-            return
-
-        return self.source_metadata.get("relation")
 
 
 class ArckVernacular(ContentdmVernacular):

--- a/metadata_mapper/mappers/oai/contentdm/arck_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/arck_mapper.py
@@ -8,7 +8,7 @@ class ArckRecord(ContentdmRecord):
         return {
             "source": self.source_metadata.get("source"),
             "isShownBy": self.source_metadata.get("relation"),
-            "relation": ""
+            "relation": None
         }
 
 

--- a/metadata_mapper/mappers/oai/contentdm/csudh_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm/csudh_mapper.py
@@ -4,7 +4,7 @@ from ..contentdm_mapper import ContentdmRecord, ContentdmVernacular
 class CsudhRecord(ContentdmRecord):
     def UCLDC_map(self):
         return {
-            "identifier": self.map_identifier()
+            "identifier": self.map_identifier
         }
 
     def map_identifier(self):

--- a/metadata_mapper/mappers/oai/contentdm_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm_mapper.py
@@ -40,10 +40,10 @@ class ContentdmRecord(OaiRecord):
 
     def map_type(self):
         """Used by map_is_shown_by() in this class, so cannot be directly added to the mapping"""
-        return self.split_and_flatten('type')
+        return self.split_and_flatten('type')()
 
     def map_spatial(self):
-        values = [v for v in self.collate_fields(["coverage", "spatial"]) if v]
+        values = [v for v in self.collate_fields(["coverage", "spatial"])() if v]
         if not values:
             return
 
@@ -56,7 +56,7 @@ class ContentdmRecord(OaiRecord):
         if not subject:
             return
 
-        return [{'name': v} for v in self.split_and_flatten('subject')]
+        return [{'name': v} for v in self.split_and_flatten('subject')()]
 
     def get_preview_image_url(self):
         """

--- a/metadata_mapper/mappers/oai/contentdm_mapper.py
+++ b/metadata_mapper/mappers/oai/contentdm_mapper.py
@@ -11,10 +11,10 @@ class ContentdmRecord(OaiRecord):
         return {
             "contributor": self.split_and_flatten('contributor'),
             "creator": self.split_and_flatten('creator'),
-            "spatial": self.map_spatial(),
-            "type": self.map_type(),
+            "spatial": self.map_spatial,
+            "type": self.map_type,
             "language": self.split_and_flatten('language'),
-            "subject": self.map_subject()
+            "subject": self.map_subject
         }
 
     def map_is_shown_at(self):

--- a/metadata_mapper/mappers/oai/csu_dspace/csuci_mapper.py
+++ b/metadata_mapper/mappers/oai/csu_dspace/csuci_mapper.py
@@ -4,7 +4,7 @@ from ..csu_dspace_mapper import CsuDspaceRecord, CsuDspaceVernacular
 class CsuciRecord(CsuDspaceRecord):
     def UCLDC_map(self):
         return {
-            "type": self.map_type()
+            "type": self.map_type
         }
 
     def map_type(self):

--- a/metadata_mapper/mappers/oai/oai_mapper.py
+++ b/metadata_mapper/mappers/oai/oai_mapper.py
@@ -15,8 +15,8 @@ class OaiRecord(Record):
         return {
             # `legacy_couch_db_id` is set by a premapping function
             'calisphere-id': self.legacy_couch_db_id.split('--')[1],
-            'isShownAt': self.map_is_shown_at(),
-            'isShownBy': self.map_is_shown_by(),
+            'isShownAt': self.map_is_shown_at,
+            'isShownBy': self.map_is_shown_by,
             'contributor': self.source_metadata.get('contributor'),
             'creator': self.source_metadata.get('creator'),
             'date': self.collate_fields([
@@ -54,7 +54,7 @@ class OaiRecord(Record):
             ]),
             'rights': self.collate_fields(['accessRights', 'rights']),
             'spatial': self.collate_fields(['coverage', 'spatial']),
-            'subject': self.map_subject(),
+            'subject': self.map_subject,
             'temporal': self.source_metadata.get('temporal'),
             'title': self.source_metadata.get('title'),
             'type': self.source_metadata.get('type')

--- a/metadata_mapper/utilities.py
+++ b/metadata_mapper/utilities.py
@@ -1,0 +1,11 @@
+from typing import Callable
+
+
+def returns_callable(func: Callable) -> Callable:
+    """
+    A decorator that returns a lambda that calls the wrapped function when invoked
+    """
+    def inner(*args, **kwargs):
+        return lambda: func(*args, **kwargs)
+
+    return inner


### PR DESCRIPTION
This is not ready for review. Further changes to the mapper approach are necessary to prevent parent mappers from being called during the build process.
