### PR TITLE
Set up docker dev env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Continuous Integration
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Run Ruff
+        run: ruff check --format=github .

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ rikolti_bucket/
 samconfig.toml
 
 # For running in Docker container
-.bash_history
-.ipython
-.cache
-.local
+/.bash_history
+/.ipython
+/.cache
+/.local

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ local_settings.py
 rikolti_bucket/
 .aws-sam/
 samconfig.toml
+
+# For running in Docker container
+.bash_history
+.ipython
+.cache
+.local

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,8 @@ local_settings.py
 rikolti_bucket/
 .aws-sam/
 samconfig.toml
-
-# For running in Docker container
 /.bash_history
 /.ipython
 /.cache
 /.local
+!/.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9
+
+RUN /usr/local/bin/python -m pip install --upgrade pip
+
+RUN adduser rikolti
+USER rikolti
+WORKDIR /home/rikolti
+
+ENV PATH="$PATH:/home/rikolti/.local/bin"
+
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ cd ~/Projects/
 git clone git@github.com:ucldc/rikolti.git
 ```
 
+### OSX
+
 Set up a python environment using python version 3.9. I'm working on a mac with a bash shell. I use [pyenv](https://github.com/pyenv/pyenv) to manage python versions and I use [python3 venv](https://docs.python.org/3/library/venv.html) to manage a python virtual environment located in `~/.venv/rikolti/`. The following commands are meant to serve as a guide - please check the installation instructions for pyenv for your own environment. 
 
 ```sh
@@ -46,6 +48,28 @@ pip install -r requirements.txt
 Currently, I only use one virtual environment, even though each folder located at the root of this repository represents an isolated component. If dependency conflicts are encountered, I'll wind up creating separate environments.
 
 Note: We tried using `sam local` to develop the app locally and found that the overhead makes for a clunky and slow process that doesn't offer advantages over the local virtualenv development setup described above. We are using AWS SAM to build and deploy the lambda applications, however ([see below](#deploying-using-aws-sam)).
+
+### Docker
+
+After cloning the repo, run `script/up` to build and start the container. The 
+container will continue running until stopped. As most development tasks take place in 
+the Python console, there are two commands for starting the console in the 
+metadata_fetcher and metadata_mapper modules. They are:
+
+`bin/map` - starts the console from within the mapper module
+
+`bin/fetch` - starts the console from within the fetcher module
+
+These commands install pip requirements and start an ipython console session.
+
+The `autoreload` ipython extension is automatically loaded. Typing 
+`autoreload` or, just `r` in the console with reload all loaded modules.
+
+To run other commands in the container, run `docker compose exec` from the 
+project root:
+
+`docker compose exec python ls -al`
+
 
 ## Development Contribution Process
 The [Rikolti Wiki](https://github.com/ucldc/rikolti/wiki/) contains lots of helpful technical information. The [GitHub Issues](https://github.com/ucldc/rikolti/issues) tool tracks Rikolti development tasks. We organize issues using the GitHub project board [Rikolti MVP](https://github.com/orgs/ucldc/projects/1/views/1) to separate work out into [Milestones](https://github.com/ucldc/rikolti/milestones) and [Sprints](https://github.com/orgs/ucldc/projects/1/views/5). 

--- a/bin/fetch
+++ b/bin/fetch
@@ -1,0 +1,2 @@
+bin/install_dev_requirements
+docker compose exec -w /home/rikolti/metadata_fetcher python ipython

--- a/bin/install_dev_requirements
+++ b/bin/install_dev_requirements
@@ -1,0 +1,2 @@
+docker compose exec python pip install -q -r /home/rikolti/requirements_dev.txt
+docker compose cp ./docker/.ipython/profile_default/startup/bootstrap.py python:/home/rikolti/.ipython/profile_default/startup/

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,1 @@
+docker compose exec python ruff check .

--- a/bin/map
+++ b/bin/map
@@ -1,0 +1,2 @@
+bin/install_dev_requirements
+docker compose exec -w /home/rikolti/metadata_mapper python ipython

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  python:
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    volumes:
+      - .:/home/rikolti

--- a/docker/.ipython/profile_default/startup/bootstrap.py
+++ b/docker/.ipython/profile_default/startup/bootstrap.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+
+import os
+import glob
+import importlib
+from pprint import pprint
+
+get_ipython().run_line_magic("load_ext", "autoreload")
+get_ipython().run_line_magic("alias_magic", "r %autoreload")
+
+# import all modules in the current cwd excluding some
+excludes = ["tests", "utilities", "settings", "__init__"]
+paths = glob.glob(f"{os.getcwd()}/*.py")
+
+for path in paths:
+    if any([exclude in path for exclude in excludes]):
+        continue
+
+    module = os.path.basename(path)[:-3]
+
+    locals()[module] = importlib.import_module(module)

--- a/metadata_mapper/tests.py
+++ b/metadata_mapper/tests.py
@@ -4,7 +4,7 @@ import settings
 import logging
 import os
 from lambda_shepherd import map_collection
-from validate_mapping import validate_mapped_collection
+from validate_mapping import validate_collection
 from sample_data.nuxeo_harvests import nuxeo_harvests, \
     nuxeo_complex_object_harvests, nuxeo_nested_complex_object_harvests
 from sample_data.oac_harvests import oac_harvests
@@ -41,7 +41,7 @@ def test_static_samples():
 
     for harvest in harvests:
         print(f"validate mapping: {json.dumps(harvest)}")
-        validate_mapped_collection(json.dumps(harvest))
+        validate_collection(json.dumps(harvest))
         print(f"validated: {str(harvest)}")
 
 

--- a/metadata_mapper/validate_registry_collections.py
+++ b/metadata_mapper/validate_registry_collections.py
@@ -7,7 +7,7 @@ import logging
 import settings
 import urllib3
 from datetime import datetime
-from validate_mapping import validate_mapped_collection
+from validate_mapping import validate_collection
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -50,7 +50,7 @@ def validate_endpoint(url):
             ))
             logging.debug(log_msg.format(f"lambda payload: {collection}"))
             try:
-                collection_validation = validate_mapped_collection(
+                collection_validation = validate_collection(
                     json.dumps(collection))
             except FileNotFoundError:
                 print(f"[{collection_id}]: not fetched yet")

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,3 @@
+-r ./metadata_mapper/requirements.txt
+-r ./metadata_fetcher/requirements.txt
+ipython

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 -r ./metadata_mapper/requirements.txt
 -r ./metadata_fetcher/requirements.txt
 ipython
+ruff

--- a/script/up
+++ b/script/up
@@ -1,0 +1,1 @@
+docker compose up

--- a/script/up
+++ b/script/up
@@ -1,1 +1,1 @@
-docker compose up
+docker compose up $1


### PR DESCRIPTION
@amywieliczka and @barbarahui, I took a little of my own time and Dockerized this project, basically making it so developer environments can be run in a container. I updated the README with instructions, it's quite simple. It primarily facilitates what I have to do a lot when developing locally.

Here are the top line takeaways:

- Using ipython
- Can start console in either the fetcher or mapper module
- Modules inside the cwd are autoloaded when the console starts
- Use `autoreload` to reload all loaded modules

I've tested this, but haven't done any development with it, so I've yet to see how much of an improvement it is, but not having to deal with pyenv, the easy reloading, plus everything else that comes with ipython should make things a bit easier.

Downsides:

- There's a hardcoded background color in ipython that can't be changed, I had to configure my terminal to remap it to something sane (after pulling my hair out for a while), see: https://github.com/ipython/ipython/issues/13446
- There's an intermittent issue where, for example, after reloading while working on a mapper I'll get an error that the vernacular class doesn't extend Vernacular, requiring a restart of the console.

We haven't discussed this, but I thought you might be interested in trying it out to see how you like it.

Also: I haven't dug into it yet, but starting `bin/map` does result in an error right now, which might indicate something that needs to be fixed in the main branch.