### PR TITLE
Fetcher local recursion

### DIFF
--- a/metadata_fetcher/fetchers/Fetcher.py
+++ b/metadata_fetcher/fetchers/Fetcher.py
@@ -82,7 +82,8 @@ class Fetcher(object):
             raise FetchError(
                 f"[{self.collection_id}]: unable to fetch page {page}")
 
-        if self.check_page(response):
+        record_count = self.check_page(response)
+        if record_count:
             content = self.aggregate_vernacular_content(response)
             if settings.DATA_DEST == 'local':
                 self.fetchtolocal(content)
@@ -91,7 +92,7 @@ class Fetcher(object):
 
         self.increment(response)
 
-        return self.json()
+        return record_count
 
     def aggregate_vernacular_content(self, response):
         return response.text

--- a/metadata_fetcher/fetchers/flickr_fetcher.py
+++ b/metadata_fetcher/fetchers/flickr_fetcher.py
@@ -165,12 +165,12 @@ class FlickrFetcher(Fetcher):
         session.mount("https://", HTTPAdapter(max_retries=retries))
         return session.get(url=url)
 
-    def check_page(self, http_resp: requests.Response) -> bool:
+    def check_page(self, http_resp: requests.Response) -> int:
         """
         Parameters:
             http_resp: requests.Response
 
-        Returns: bool
+        Returns: int
         """
         data = json.loads(http_resp.content)
         self.photo_total = len(data.get(self.response_items_attribute, {}).
@@ -181,7 +181,7 @@ class FlickrFetcher(Fetcher):
             f"at {http_resp.url} with {self.photo_total} hits"
         )
 
-        return True
+        return self.photo_total
 
     def increment(self, http_resp: requests.Response):
         """

--- a/metadata_fetcher/fetchers/nuxeo_fetcher.py
+++ b/metadata_fetcher/fetchers/nuxeo_fetcher.py
@@ -141,7 +141,7 @@ class NuxeoFetcher(Fetcher):
 
         return request
 
-    def check_page(self, http_resp):
+    def check_page(self, http_resp: requests.Response) -> int:
         """Checks that the http_resp contains metadata records
 
         Also recurses down into documents & folders, calling
@@ -157,7 +157,7 @@ class NuxeoFetcher(Fetcher):
         response = http_resp.json()
         query_type = self.nuxeo.get('query_type')
 
-        documents = False
+        documents = 0
         if query_type in ['documents', 'children'] and response.get('entries'):
             print(
                 f"[{self.collection_id}]: "
@@ -170,7 +170,7 @@ class NuxeoFetcher(Fetcher):
                 num_docs = self.nuxeo.get('doc_count', [])
                 self.nuxeo['doc_count'] = (
                     num_docs + [len(response.get('entries'))])
-            documents = True
+            documents = len(response.get('entries'))
 
         if ((query_type == 'documents' and self.nuxeo['fetch_children'])
                 or query_type == 'folders'):

--- a/metadata_fetcher/fetchers/oac_fetcher.py
+++ b/metadata_fetcher/fetchers/oac_fetcher.py
@@ -76,7 +76,7 @@ class OacFetcher(Fetcher):
 
         return request
 
-    def check_page(self, http_resp):
+    def check_page(self, http_resp: requests.Response) -> int:
         xml_resp = ElementTree.fromstring(http_resp.content)
         xml_hits = (xml_resp.find('facet').findall('./group/docHit'))
         if len(xml_hits) > 0:
@@ -91,7 +91,7 @@ class OacFetcher(Fetcher):
                 f"at {requested_url} "
                 f"with {len(xml_hits)} hits"
             )
-        return bool(len(xml_hits))
+        return len(xml_hits)
 
     def increment(self, http_resp):
         super(OacFetcher, self).increment(http_resp)

--- a/metadata_fetcher/fetchers/oai_fetcher.py
+++ b/metadata_fetcher/fetchers/oai_fetcher.py
@@ -3,6 +3,7 @@ from xml.etree import ElementTree
 from .Fetcher import Fetcher
 from urllib.parse import parse_qs
 from sickle import Sickle
+import requests
 
 NAMESPACE = {'oai2': 'http://www.openarchives.org/OAI/2.0/'}
 
@@ -60,7 +61,7 @@ class OaiFetcher(Fetcher):
         request = {"url": url}
         return request
 
-    def check_page(self, http_resp):
+    def check_page(self, http_resp: requests.Response) -> int:
         xml_resp = ElementTree.fromstring(http_resp.content)
         xml_hits = xml_resp.find(
             'oai2:ListRecords', NAMESPACE).findall('oai2:record', NAMESPACE)
@@ -70,7 +71,7 @@ class OaiFetcher(Fetcher):
                 f"[{self.collection_id}]: Fetched page {self.write_page}; "
                 f"{len(xml_hits)} hits; {self.build_fetch_request()['url']}"
             )
-        return bool(len(xml_hits))
+        return len(xml_hits)
 
     def increment(self, http_resp):
         super(OaiFetcher, self).increment(http_resp)


### PR DESCRIPTION
Review bug-fixes PR first

This branch implements some better reporting on fetching tasks:
- `check_page` returns the number of records found on the fetched page, rather than a boolean - updated for the 4 existing fetchers; @lthurston please indicate if this is a problem moving forwards
- `fetch_page` method returns the number of records found on the fetched page, as reported by the `check_page` method
- `lambda_function.fetch_collection` has a more thorough and detailed return value
- `lambda_function.fetch_collection` extends the return value for all pages when run recursively in the local environment
- `fetch_registry_collections.fetch_endpoint` makes use of this return value to provide details about how many records were fetched over how many pages