### PR TITLE
Validator Improvements Mk. II

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ samconfig.toml
 /.cache
 /.local
 !/.github
+
+__pycache__

--- a/metadata_mapper/__init__.py
+++ b/metadata_mapper/__init__.py
@@ -1,1 +1,2 @@
 import utilities
+import validator

--- a/metadata_mapper/lambda_shepherd.py
+++ b/metadata_mapper/lambda_shepherd.py
@@ -7,6 +7,8 @@ from lambda_function import map_page
 import settings
 import logging
 
+import validate_mapping
+
 
 def get_collection(collection_id):
     collection = requests.get(
@@ -58,6 +60,7 @@ def map_collection(payload, context):
 
     count = 0
     page_count = 0
+
     if settings.DATA_SRC == 'local':
         vernacular_path = settings.local_path(
             'vernacular_metadata', collection_id)
@@ -111,6 +114,14 @@ def map_collection(payload, context):
                 InvocationType="Event",  # invoke asynchronously
                 Payload=json.dumps(payload).encode('utf-8')
             )
+
+    validate = payload.get("validate")
+    if validate:
+        validate_mapping.create_collection_validation_csv(
+            collection_id,
+            **validate
+            )
+
     return {
         'statusCode': 200,
         'body': {

--- a/metadata_mapper/lambda_shepherd.py
+++ b/metadata_mapper/lambda_shepherd.py
@@ -69,11 +69,9 @@ def map_collection(payload, context):
                          if os.path.isfile(os.path.join(vernacular_path, f))]
             children_path = os.path.join(vernacular_path, 'children')
             if os.path.exists(children_path):
-                page_list += [
-                    os.path.join('children', f)
-                    for f in os.listdir(children_path)
-                    if os.path.isfile(os.path.join(children_path, f))
-                ]
+                page_list += [os.path.join('children', f)
+                              for f in os.listdir(children_path)
+                              if os.path.isfile(os.path.join(children_path, f))]
         except FileNotFoundError as e:
             logging.debug(f"{e} - have you fetched {collection_id}?")
             return {
@@ -117,9 +115,10 @@ def map_collection(payload, context):
 
     validate = payload.get("validate")
     if validate:
+        opts = validate if isinstance(validate, dict) else {}
         validate_mapping.create_collection_validation_csv(
             collection_id,
-            **validate
+            **opts
             )
 
     return {

--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -12,7 +12,8 @@ from typing import Any, Callable
 from datetime import date
 
 import settings
-from .validator import Validator, ValidationErrors
+from validator.validator import Validator
+from validator.validation_log import ValidationLog
 
 from . import constants
 from .iso639_1 import iso_639_1
@@ -139,7 +140,7 @@ class Record(ABC, object):
         return {}
 
     # Validation
-    def validate(self, comparison_data: dict) -> ValidationErrors:
+    def validate(self, comparison_data: dict) -> ValidationLog:
         return self.validator.validate(self.mapped_metadata, comparison_data)
 
     # Mapper Helpers

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -8,14 +8,19 @@ from typing import Type
 import settings
 import utilities
 
-from mappers.validator import Validator
+from validator.validator import Validator
+from validator.validation_mode import ValidationMode
+from validator.validation_log import ValidationLogLevel
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 def validate_collection(collection_id: int,
                         validator_class: Type[Validator] = None,
-                        validator: Validator = None
+                        validator: Validator = None,
+                        default_validation_mode = ValidationMode.STRICT,
+                        log_level = ValidationLogLevel.WARNING,
+                        verbose = False
                         ) -> Validator:
     """
     Validates all pages of a collection of mapped data.
@@ -35,7 +40,9 @@ def validate_collection(collection_id: int,
         validator_class = get_validator_class(collection_id)
 
     if not validator:
-        validator = validator_class()
+        validator = validator_class(default_validation_mode=default_validation_mode,
+                                    log_level = log_level,
+                                    verbose = verbose)
 
     for page_id in utilities.get_files("mapped_metadata", collection_id):
         validate_page(collection_id, page_id, validator)
@@ -99,10 +106,10 @@ def validate_page(collection_id: int, page_id: int,
 
 def create_collection_validation_csv(collection_id: int) -> None:
     result = validate_collection(collection_id)
-    result.errors.output_csv_to_bucket(collection_id)
+    result.log.output_csv_to_bucket(collection_id)
 
 
-## Private
+## Private-ish
 
 
 def get_mapped_data(collection_id: int, page_id: int) -> dict:

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -18,7 +18,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 def validate_collection(collection_id: int,
                         validator_class: Type[Validator] = None,
                         validator: Validator = None,
-                        default_validation_mode = ValidationMode.STRICT,
+                        validation_mode = ValidationMode.STRICT,
                         log_level = ValidationLogLevel.WARNING,
                         verbose = False
                         ) -> Validator:
@@ -32,6 +32,12 @@ def validate_collection(collection_id: int,
             The validator class to use. Can be derived if not provided.
         validator: Validator (default: None)
             A validator instance to use. Can be derived if not provided.
+        validation_mode: ValidationMode (default: ValidationMode.STRICT)
+            The validation mode to use (unless overridden in individual validations)
+        log_level: ValidationLogLevel (default: ValidationLogLevel.WARNING)
+            The lowest log level that should be included in the output
+        verbose: bool (default: False)
+            Include verbose output in file?
 
     Returns: Validator
         The validator containing errors
@@ -40,7 +46,7 @@ def validate_collection(collection_id: int,
         validator_class = get_validator_class(collection_id)
 
     if not validator:
-        validator = validator_class(default_validation_mode=default_validation_mode,
+        validator = validator_class(validation_mode=validation_mode,
                                     log_level = log_level,
                                     verbose = verbose)
 

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -13,58 +13,6 @@ from mappers.validator import Validator
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
-def solr(**params):
-    solr_url = f'{settings.SOLR_URL}/query/'
-    solr_auth = {'X-Authentication-Token': settings.SOLR_API_KEY}
-    query = {}
-    for key, value in list(params.items()):
-        key = key.replace('_', '.')
-        query.update({key: value})
-    res = requests.post(solr_url, headers=solr_auth, data=query, verify=False)
-    res.raise_for_status()
-    return json.loads(res.content.decode('utf-8'))
-
-
-def get_mapped_data(collection_id: int, page_id: int) -> dict:
-    return utilities.read_mapped_metadata(collection_id, page_id)
-
-
-def get_solr_data(collection_id: int, ids: list[str]) -> list[dict]:
-    collection_url = ("collection_url:\"https://registry.cdlib.org/api/v1/"
-                      f"collection/{collection_id}/\"")
-    harvest_id_q = " OR ".join([f"harvest_id_s:\"{f}\"" for f in ids])
-    query = {
-        'fq': f"{collection_url} AND ({harvest_id_q})",
-        'rows': len(ids),
-        'start': 0
-    }
-
-    response = solr(**query)
-    return response.get("response", {"docs": None}).get("docs", [])
-
-
-def get_validator_class(collection_id: int) -> Type[Validator]:
-    url = ("https://registry.cdlib.org/api/v1/rikoltimapper/"
-           f"{collection_id}/?format=json")
-
-    try:
-        response = requests.get(url=url)
-        response.raise_for_status()
-        collection_data = response.json()
-    except requests.exceptions.HTTPError as err:
-        print(
-            f"[Collection {collection_id}]: "
-            f"[{url}]"
-            f"{err}; A valid collection id is required for validation"
-        )
-        return
-
-    mapper = collection_data.get("rikolti_mapper_type")
-    vernacular = utilities.import_vernacular_reader(mapper)
-
-    return vernacular.record_cls.validator
-
-
 def validate_collection(collection_id: int,
                         validator_class: Type[Validator] = None,
                         validator: Validator = None
@@ -120,20 +68,21 @@ def validate_page(collection_id: int, page_id: int,
                         type="Rikolti",
                         context=context
                       )
-    solr_data = validator.generate_keys(
-                    get_solr_data(collection_id, list(mapped_metadata.keys())),
-                    type="Solr",
-                    context=context
-                )
+    comparison_data = validator.generate_keys(
+                        get_comparison_data(collection_id,
+                                            list(mapped_metadata.keys())),
+                        type="Solr",
+                        context=context
+                      )
 
-    if len(mapped_metadata) == 0 or len(solr_data) == 0:
+    if len(mapped_metadata) == 0 or len(comparison_data) == 0:
         print("No data found in "
               f"{'mapped Rikolti data' if len(mapped_metadata) else 'Solr'}."
               " Aborting."
               )
         return
 
-    all_keys = set(mapped_metadata.keys()).union(set(solr_data.keys()))
+    all_keys = set(mapped_metadata.keys()).union(set(comparison_data.keys()))
 
     if len(all_keys) == 0:
         print("No data found. Aborting.")
@@ -141,7 +90,7 @@ def validate_page(collection_id: int, page_id: int,
 
     for harvest_id in all_keys:
         rikolti_record = mapped_metadata.get(harvest_id)
-        solr_record = solr_data.get(harvest_id)
+        solr_record = comparison_data.get(harvest_id)
 
         validator.validate(harvest_id, rikolti_record, solr_record)
 
@@ -151,6 +100,107 @@ def validate_page(collection_id: int, page_id: int,
 def create_collection_validation_csv(collection_id: int) -> None:
     result = validate_collection(collection_id)
     result.errors.output_csv_to_bucket(collection_id)
+
+
+## Private
+
+
+def get_mapped_data(collection_id: int, page_id: int) -> dict:
+    return utilities.read_mapped_metadata(collection_id, page_id)
+
+
+def get_comparison_data(collection_id: int, harvest_ids: list[str]) -> list[dict]:
+    solr_data = get_solr_data(collection_id, harvest_ids)
+    couch_data = get_couch_db_data(collection_id, harvest_ids)
+
+    return [
+      {**solr_dict, **(couch_data[solr_dict["harvest_id_s"]] or {})}
+      for solr_dict in solr_data
+    ]
+
+
+def get_solr_data(collection_id: int, harvest_ids: list[str]) -> list[dict]:
+    collection_url = ("collection_url:\"https://registry.cdlib.org/api/v1/"
+                      f"collection/{collection_id}/\"")
+    harvest_id_q = " OR ".join([f"harvest_id_s:\"{f}\"" for f in harvest_ids])
+    query = {
+        'fq': f"{collection_url} AND ({harvest_id_q})",
+        'rows': len(harvest_ids),
+        'start': 0
+    }
+
+    response = make_solr_request(**query)
+    return response.get("response", {"docs": None}).get("docs", [])
+
+
+def make_solr_request(**params):
+    """Makes the request against Solr based on provided params"""
+    solr_url = f'{settings.SOLR_URL}/query/'
+    solr_auth = {'X-Authentication-Token': settings.SOLR_API_KEY} 
+    query = {}
+    for key, value in list(params.items()):
+        key = key.replace('_', '.')
+        query.update({key: value})
+    res = requests.post(solr_url, headers=solr_auth, data=query, verify=False)
+    res.raise_for_status()
+    return json.loads(res.content.decode('utf-8'))
+
+
+def get_couch_db_data(collection_id: int,
+                      harvest_ids: list[str]) -> dict[str, dict[str, str]]:
+    """
+    Requests isShownAt and isShownBy data from Couch DB.
+
+    Data is returned as a list of single-entry dicts, so we'll
+    parse them out into a dict[str, dict[str, str]] where the keys are
+    harvest_ids and the 
+    """
+    # This method get ALL data for the collection, then pares it down
+    # TODO: See if there's a way to improve the query to only get relevant data
+    # TODO: See if there's a way to get both fields in a single query
+    ret = {}
+
+    for field_name in ["isShownAt", "isShownBy"]:  
+      url = "https://harvest-prd.cdlib.org/" \
+            "couchdb/ucldc/_design/all_provider_docs/" \
+            "_list/has_field_value/by_provider_name_wdoc" \
+            f"?key=\"{collection_id}\"&field={field_name}&limit=1000"
+      
+      #### TODO: REMOVE verify=False once cert issues are resolved!
+      response = requests.get(url, verify=False)
+      data = {}
+      for d in json.loads(response.content):
+          key = list(d.keys())[0]
+          data[key] = {field_name: d[key]}
+
+      ret = {
+              key: {**(ret.get(key) or {}), **(data.get(key) or {})}
+              for key in harvest_ids
+            }
+
+    return ret
+
+
+def get_validator_class(collection_id: int) -> Type[Validator]:
+    url = ("https://registry.cdlib.org/api/v1/rikoltimapper/"
+           f"{collection_id}/?format=json")
+
+    try:
+        response = requests.get(url=url)
+        response.raise_for_status()
+        collection_data = response.json()
+    except requests.exceptions.HTTPError as err:
+        print(
+            f"[Collection {collection_id}]: "
+            f"[{url}]"
+            f"{err}; A valid collection id is required for validation"
+        )
+        return
+
+    mapper = collection_data.get("rikolti_mapper_type")
+    vernacular = utilities.import_vernacular_reader(mapper)
+
+    return vernacular.record_cls.validator
 
 
 if __name__ == "__main__":

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -225,12 +225,14 @@ if __name__ == "__main__":
     args = parser.parse_args(sys.argv[1:])
 
     opt_args = ["log_level", "verbose", "filename"]
-    kwargs = {attrname: getattr(args, attrname) for attrname in opt_args if getattr(args, attrname)}
+    kwargs = {attrname: getattr(args, attrname)
+              for attrname in opt_args
+              if getattr(args, attrname)}
 
     if kwargs.get("log_level"):
       kwargs["log_level"] = getattr(ValidationLogLevel, args.log_level.upper())
 
-    print(f"Generating validation file for collection {args.collection_id} with options:")
+    print(f"Generating validations for collection {args.collection_id} with options:")
     print(kwargs)
 
     collection_report = create_collection_validation_csv(args.collection_id, **kwargs)

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -90,7 +90,7 @@ def validate_page(collection_id: int, page_id: int,
 
     if len(mapped_metadata) == 0 or len(comparison_data) == 0:
         print("No data found in "
-              f"{'mapped Rikolti data' if len(mapped_metadata) else 'Solr'}."
+              f"{'mapped Rikolti data' if len(mapped_metadata) == 0 else 'Solr'}."
               " Aborting."
               )
         return

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -174,8 +174,7 @@ def get_couch_db_data(collection_id: int,
             "_list/has_field_value/by_provider_name_wdoc" \
             f"?key=\"{collection_id}\"&field={field_name}&limit=1000"
       
-      #### TODO: REMOVE verify=False once cert issues are resolved!
-      response = requests.get(url, verify=False)
+      response = requests.get(url)
       data = {}
       for d in json.loads(response.content):
           key = list(d.keys())[0]

--- a/metadata_mapper/validator/__init__.py
+++ b/metadata_mapper/validator/__init__.py
@@ -1,0 +1,3 @@
+from .validator import Validator
+from .validation_log import ValidationLog, ValidationLogLevel
+from .validation_mode import ValidationMode

--- a/metadata_mapper/validator/validation_log.py
+++ b/metadata_mapper/validator/validation_log.py
@@ -1,0 +1,195 @@
+from datetime import datetime
+from enum import Enum
+from typing import Any, IO
+
+import utilities
+
+class ValidationLogLevel(Enum):
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+
+
+class ValidationLog:    
+    CSV_FIELDS: dict[str, str] = {
+        "harvest_id": "Harvest ID",
+        "level": "Level",
+        "field": "Field",
+        "description": "Description",
+        "expected": "Expected Value",
+        "actual": "Actual Value"
+    }
+
+    def __init__(self, log_level: ValidationLogLevel = ValidationLogLevel.WARNING):
+        self.log: list[dict[str, Any]] = []
+        self.level = log_level
+
+    def set_log_level(self, log_level: ValidationLogLevel) -> None:
+        self.level = log_level
+
+    def has_entries(self):
+        return True if len(self.log) else False
+
+    def is_empty(self):
+        return not self.has_entries()
+
+    def add(self, key: str, field: str, description: str, expected: Any = "",
+            actual: Any = "", level: ValidationLogLevel = ValidationLogLevel.ERROR,
+            **context) -> None:
+        """
+        Adds an entry to the log.
+
+        Parameters:
+            key: str
+                The harvest ID (or other key) used to join the Rikolti
+                and comparison record.
+            field: str
+                The field on which the entry occurred
+            description: str
+                Entry description
+            expected: Any
+                Expected value (probably from Solr)
+            actual: Any
+                Actual value (from Rikolti mapper)
+            level: ValidationLogLevel
+                Entry log level (ERROR, WARN, etc)
+            context: dict
+                Additional values to be added (will not have headers)
+        """
+        if not self._should_log(level):
+            return
+        
+        self.log.append({
+            "harvest_id": key,
+            "level": level,
+            "description": description,
+            "field": field,
+            "expected": str(expected),
+            "actual": str(actual),
+            **context
+        })
+
+    def merge(self, other_log: "ValidationLog") -> "ValidationLog":
+        """
+        Merges log list with another.
+
+        Parameters:
+            other_log: ValidationLog
+                Another ValidationLog instance to merge in
+
+        Returns: ValidationLog
+        """
+        if not other_log.log:
+            return self.log
+
+        self.log = self.log + other_log.log
+        return self.log
+
+    def output_csv_to_file(self, file: IO[str], append: bool = False,
+                           include_fields: list[str] = None) -> None:
+        """
+        Given a file, generates a CSV with log output.
+
+        Parameters:
+            file: IO[str]
+                File path to write to
+            append: bool (default: False)
+                Should this log be appended to the file?
+            include_fields: list[str] (default: None)
+                List of fields to include in the output
+        """
+        with open(file, "a" if append else "w") as f:
+            f.write(self._csv_content_string(include_fields, append))
+
+    def output_csv_to_bucket(self, collection_id: int, filename: str = None,
+                             include_fields: list[str] = None) -> None:
+        """
+        Writes a CSV to the env-appropriate bucket (local or S3).
+
+        Parameters:
+            collection_id: int
+                The collection ID (for finding appropriate folder)
+            filename: str (default: None)
+                The name of the created file. If not provided, defaults to
+                timestamp
+            include_fields: list[str] (default: None)
+                A list of fields to include in the CSV. Defaults to all.
+        """
+        if not filename:
+            filename = f"{datetime.now().strftime('%m-%d-%YT%H:%M:%S')}.csv"
+
+        utilities.write_to_bucket("validation", collection_id, filename,
+                                  self._csv_content_string(include_fields))
+
+    def _csv_content(self, include_fields: list[str] = None,
+                     include_headers: bool = True) -> list[list[str]]:
+        """
+        Generates a list from log entries suitable for generating a CSV.
+
+        Parameters:
+            include_fields: list[str] (default: None)
+                List of fields to include in the CSV. Defaults to all.
+            include_headers: bool (default: True)
+                Should a list of header values be added at the top?
+
+        Returns: list[list[str]]
+        """
+        def escape_csv_value(value):
+            return '"' + str(value).replace('"', '""') + '"'
+
+        if include_fields:
+            headers = [
+                h for (f, h) in self.CSV_FIELDS
+                if f in include_fields
+            ]
+            fields = [
+                f for f in self._default_fields
+                if f in include_fields
+            ]
+        else:
+            headers = self._default_headers
+            fields = self._default_fields
+
+        ret = [headers] if include_headers else []
+        for row in self.log:
+            ret.append(
+                [
+                    escape_csv_value(val) for key, val in row.items()
+                    if key in fields
+                ]
+            )
+
+        return ret
+
+    def _csv_content_string(self, include_fields: list[str] = None,
+                            include_headers: bool = True) -> str:
+        """
+        Generates a string of CSV content suitable for writing to a file.
+
+        Parameters:
+            include_fields: list[str] (default: None)
+                List of fields to include in the CSV. Defaults to all.
+            include_headers: bool (default: True)
+                Should a list of header values be added at the top?
+
+        Returns: str
+        """
+        content = self._csv_content(include_fields, include_headers)
+        content_strings = [",".join(row) for row in content]
+        return "\n".join(content_strings)
+
+    def _should_log(self, log_level) -> bool:
+        for level in list(ValidationLogLevel.__members__):
+            if level == self.level.value:
+                return True
+            elif level == log_level.value:
+                return False
+
+    @property
+    def _default_fields(self) -> list[str]:
+        return list(self.CSV_FIELDS.keys())
+
+    @property
+    def _default_headers(self) -> list[str]:
+        return list(self.CSV_FIELDS.values())

--- a/metadata_mapper/validator/validation_log.py
+++ b/metadata_mapper/validator/validation_log.py
@@ -121,6 +121,8 @@ class ValidationLog:
 
         utilities.write_to_bucket("validation", collection_id, filename,
                                   self._csv_content_string(include_fields))
+        
+        return filename
 
     def _csv_content(self, include_fields: list[str] = None,
                      include_headers: bool = True) -> list[list[str]]:

--- a/metadata_mapper/validator/validation_mode.py
+++ b/metadata_mapper/validator/validation_mode.py
@@ -1,0 +1,56 @@
+from abc import ABC
+from enum import Enum
+from typing import Any
+
+class ValidationMode(Enum):
+
+    class Mode(ABC):
+        def compare(self, one: Any, two: Any) -> bool:
+            if type(one) == type(two):
+                type_str = type(one).__name__
+                fn = getattr(self, f"{type_str}_compare")
+                return fn(one, two)
+            else:
+                return self.any_compare(one, two)
+        
+        def str_compare(self, one: str, two: str) -> bool:
+            return one == two
+
+        def list_compare(self, one: list, two: list) -> bool:
+            return one == two
+
+        def dict_compare(self, one: dict, two: dict) -> bool:
+            return one == two
+
+        def NoneType_compare(self, one: None, two: None) -> bool:
+            return True
+        
+        def any_compare(self, one: Any, two: Any) -> bool:
+            return False
+        
+
+    class StrictMode(Mode):
+        """
+        Strict validation mode generally requires exact matches to pass.
+        """
+        pass
+
+
+    class LaxMode(Mode):
+        """
+        Lax validation mode generally permits case- and order-insensitive comparisons.
+        """
+        @staticmethod
+        def str_compare(one, two):
+            return one.lower() == two.lower()
+
+        @staticmethod
+        def list_compare(one: list, two: list) -> bool:
+            return sorted(one) == sorted(two)
+
+        def any_compare(self, one: Any, two: Any) -> bool:
+            return str(one) == str(two)
+        
+
+    STRICT = StrictMode()
+    LAX = LaxMode()

--- a/metadata_mapper/validator/validator.py
+++ b/metadata_mapper/validator/validator.py
@@ -9,7 +9,7 @@ class Validator:
 
     def __init__(self, **options):
         self.log = ValidationLog(options.get("log_level", ValidationLogLevel.WARNING))
-        self.default_validation_mode = options.get("default_validation_mode",
+        self.default_validation_mode = options.get("validation_mode",
                                                    ValidationMode.STRICT)
         self.verbose = options.get("verbose", False)
         self.setup()
@@ -66,19 +66,12 @@ class Validator:
 
     def set_validatable_fields(self, fields: list[dict[str, Any]]) -> list[dict]:
         """
-        Set and/or overrides fields to be validated.
-
-        If merge is True, merges provided fields into
-        default_validatable_fields, overriding same-named keys.
-
-        If merge is False, simply sets the fields to the provided list.
+        Sets fields to be validated, replacing defaults.
 
         Parameters:
             fields: list[dict[str, Any]] (default: [])
                 A list of dicts containing validation definitions.
                 See default_validatable_fields for examples.
-            merge: bool (default: True)
-                Should `fields` be merged into `default_validatable_fields`?
 
         Returns list[dict]
         """

--- a/metadata_mapper/validator/validator.py
+++ b/metadata_mapper/validator/validator.py
@@ -95,7 +95,7 @@ class Validator:
                               replace: bool = True
                               ) -> bool:
         """
-        Adds a validatable field
+        Adds a single validatable field.
         """
         existing = [f for f in self.validatable_fields if f["field"] == field]
         if len(existing) > 0:

--- a/metadata_mapper/validator/validator.py
+++ b/metadata_mapper/validator/validator.py
@@ -334,7 +334,7 @@ class Validator:
             raw_results = validator(validation_def, rikolti_value, comp_value)
             normalized_results = self._normalize_validator_results(raw_results)
 
-            if len(normalized_results) > 1:
+            if len(normalized_results) > 0:
                 for result in normalized_results:
                     self._build_entries(validation_def, result, level,
                                         rikolti_value, comp_value)


### PR DESCRIPTION
Enhances the mapping validator with additional functionality:

### Validator

* Reorganizes validator classes into their own modules within the metadata_mapper package
  * `ValidationErrors` is now `ValidationLog`
* Adds `ValidationLogLevel`
  * This enum is used to set the logging level
  * Options are `ERROR`, `WARNING`, `INFO`, `DEBUG`
* Adds `ValidationMode`
  * An enum `STRICT` or `LAX`
    * `STRICT` is the current default behavior
    * `LAX` performs case-insensitive string comparisons and order-insensitive list comparisons
  * Individual validations can define their own `validation_mode` as either `ValidationMode.STRICT` or `ValidationMode.LAX` to override the global default.
* Adds `verbose` option

* Adds successful validation logging at the `INFO` level
  * By default, outputs a single line per record, listing the successfully-validated fields
  * If `verbose` is True, outputs a line per successfully-validated field. WARNING: This can make for very long validation files.

### validate_mapping.py

* Fetches `isShownAt` and `isShownBy` from CouchDB and merges it into comparison metadata
* Added CLI args:
  * `--log-level`, which can be any one of `ERROR`, `WARN`, `INFO`, or `DEBUG` (case insensitive) (default: WARN)
  * `-v` `--verbose` to set verbose mode (default: false)
  * `--filename` to set the output file name (default: timestamp-based name)

For example:

```bash
python validate_mapping.py 12345 --log-level=INFO --verbose --filename=example.csv
```
will generate some console output telling you what's happening, and create a file in the env-appropriate bucket under "validation/{collection_id}/{filename}"

### Lambda Shepherd
* Added ability to trigger post-mapping validation by passing `validate` in the Lambda payload
  * `validate` can be a truthy boolean to run with default options, `False` to explicitly not validate, or a `dict` of options
  * The options dict can contain the same arguments as the CLI flags: `log_level`, `verbose`, and/or `filename`


Resolves #383
Resolves #386
Resolves #411 
Resolves #412 
