### PR TITLE
Validator improvements

### DIFF
--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -4,6 +4,7 @@ import sys
 import urllib3
 
 from typing import Type
+from re import sub
 
 import settings
 import utilities
@@ -172,6 +173,16 @@ def get_couch_db_data(collection_id: int,
     # This method get ALL data for the collection, then pares it down
     # TODO: See if there's a way to improve the query to only get relevant data
     # TODO: See if there's a way to get both fields in a single query
+
+    def snakeify(s):
+        res = ""
+        for i in s:
+            if i.isupper():
+                res += "_" + i.lower()
+            else:
+                res += i
+        return res
+
     ret = {}
 
     for field_name in ["isShownAt", "isShownBy"]:  
@@ -180,11 +191,11 @@ def get_couch_db_data(collection_id: int,
             "_list/has_field_value/by_provider_name_wdoc" \
             f"?key=\"{collection_id}\"&field={field_name}&limit=1000"
       
-      response = requests.get(url)
+      response = requests.get(url, verify=False)
       data = {}
       for d in json.loads(response.content):
           key = list(d.keys())[0]
-          data[key] = {field_name: d[key]}
+          data[key] = {snakeify(field_name): d[key]}
 
       ret = {
               key: {**(ret.get(key) or {}), **(data.get(key) or {})}

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -224,7 +224,7 @@ def get_validator_class(collection_id: int) -> Type[Validator]:
     mapper = collection_data.get("rikolti_mapper_type")
     vernacular = utilities.import_vernacular_reader(mapper)
 
-    return vernacular.record_cls.validator
+    return vernacular.validator if hasattr(vernacular, "validator") else Validator
 
 
 if __name__ == "__main__":

--- a/metadata_mapper/validator/validator.py
+++ b/metadata_mapper/validator/validator.py
@@ -487,7 +487,7 @@ default_validatable_fields: list[dict[str, Any]] = [
                         ]
     },
     {
-        "field": "isShownAt",
+        "field": "is_shown_at",
         "type": str,
         "validations": [
                         Validator.required_field,
@@ -495,7 +495,7 @@ default_validatable_fields: list[dict[str, Any]] = [
                         ]
     },
     {
-        "field": "isShownBy",
+        "field": "is_shown_by",
         "type": str,
         "validations": [
                         Validator.required_field,


### PR DESCRIPTION
This PR includes:

- A quick and dirty way to convert couchdb keys into snake case for easy comparison. Amy is going to revisit the names of these fields so, this may only be necessarily in the short term.
- Tweak to validator to use the specified validator class on the vernacular when present, or fall back to Validator.