### PR TITLE
CCA Vault Validator ID Workaround

### DIFF
--- a/metadata_mapper/mappers/oai/cca_vault_mapper.py
+++ b/metadata_mapper/mappers/oai/cca_vault_mapper.py
@@ -5,6 +5,11 @@ from ..mapper import Validator
 
 
 class CcaVaultRecord(OaiRecord):
+    def UCLDC_map(self):
+        return {
+            "language": self.source_metadata.get("language"),
+            "source": self.source_metadata.get("source")
+        }
 
     def map_is_shown_at(self) -> Union[str, None]:
         return self.identifier_for_image()
@@ -13,10 +18,8 @@ class CcaVaultRecord(OaiRecord):
         if not self.is_image_type():
             return
 
-        if not self.source_metadata.get("type", [])[0].lower() != "image":
-            return
-
         base_url: str = self.identifier_for_image()
+
         return f"{base_url.replace('items', 'thumbs')}?gallery=preview"
 
     def is_image_type(self) -> bool:

--- a/metadata_mapper/mappers/oai/cca_vault_mapper.py
+++ b/metadata_mapper/mappers/oai/cca_vault_mapper.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 from .oai_mapper import OaiRecord, OaiVernacular
+from ..mapper import Validator
 
 
 class CcaVaultRecord(OaiRecord):
@@ -31,5 +32,53 @@ class CcaVaultRecord(OaiRecord):
         return identifier[0] if identifier else None
 
 
+class CcaVaultValidator(Validator):
+
+    def generate_keys(self, collection: list[dict], type: str = None,
+                      context: dict = {}) -> dict[str, dict]:
+        """
+        Given a list of records, generates keys and returns a dict with the
+        original list contents as values.
+
+        This can be used to override the creation of keys for a given
+        mapper to ensure that key intersection works in the
+        validate_mapping module.
+
+        Parameters:
+            collection: list[dict]
+                Data to be added to resulting dict
+            type: str (default: None)
+                Optional context. Usually this will be used to tell
+                this method if it's dealing with Rikolti or Solr data.
+            context: dict (default: {})
+                Any information needed to perform these calculations.
+
+        Returns: dict[str, dict]
+            dict of dicts, keyed to ensure successful intersection.
+        """
+        if type == "Rikolti":
+            # "oai:vault.cca.edu:" is new style, 3433 uses it
+            # "oai:cca:" is old style, 26470, 3767, 26391 use it
+            # example: 3433--oai:vault.cca.edu:006f6694-a826-6c83-b455-5b62a1ef9d69/1
+            # vs: 26470--oai:cca:0029e39d-c3f3-9346-a7d8-6565486a75a8/1
+            if context.get('collection_id') == '3433':
+                # do the usual thing
+                return {
+                    f"{context.get('collection_id')}--{r['calisphere-id']}": r
+                    for r in collection
+                }
+            else:
+                shimmed_ids = {}
+                for r in collection:
+                    item_id = r['calisphere-id'].split(':')[-1]
+                    rikolti_id = (
+                        f"{context.get('collection_id')}--oai:cca:{item_id}"
+                    )
+                    shimmed_ids[rikolti_id] = r
+                return shimmed_ids
+        elif type == "Solr":
+            return {r['harvest_id_s']: r for r in collection}
+
 class CcaVaultVernacular(OaiVernacular):
     record_cls = CcaVaultRecord
+    validator = CcaVaultValidator

--- a/metadata_mapper/mappers/oai/cca_vault_mapper.py
+++ b/metadata_mapper/mappers/oai/cca_vault_mapper.py
@@ -87,51 +87,6 @@ class CcaVaultValidator(Validator):
             validation_mode=ValidationMode.LAX
         )
 
-    # def generate_keys(self, collection: list[dict], type: str = None,
-    #                   context: dict = {}) -> dict[str, dict]:
-    #     """
-    #     Given a list of records, generates keys and returns a dict with the
-    #     original list contents as values.
-
-    #     This can be used to override the creation of keys for a given
-    #     mapper to ensure that key intersection works in the
-    #     validate_mapping module.
-
-    #     Parameters:
-    #         collection: list[dict]
-    #             Data to be added to resulting dict
-    #         type: str (default: None)
-    #             Optional context. Usually this will be used to tell
-    #             this method if it's dealing with Rikolti or Solr data.
-    #         context: dict (default: {})
-    #             Any information needed to perform these calculations.
-
-    #     Returns: dict[str, dict]
-    #         dict of dicts, keyed to ensure successful intersection.
-    #     """
-    #     if type == "Rikolti":
-    #         # "oai:vault.cca.edu:" is new style, 3433 uses it
-    #         # "oai:cca:" is old style, 26470, 3767, 26391 use it
-    #         # example: 3433--oai:vault.cca.edu:006f6694-a826-6c83-b455-5b62a1ef9d69/1
-    #         # vs: 26470--oai:cca:0029e39d-c3f3-9346-a7d8-6565486a75a8/1
-    #         if context.get('collection_id') == '3433':
-    #             # do the usual thing
-    #             return {
-    #                 f"{context.get('collection_id')}--{r['calisphere-id']}": r
-    #                 for r in collection
-    #             }
-    #         else:
-    #             shimmed_ids = {}
-    #             for r in collection:
-    #                 item_id = r['calisphere-id'].split(':')[-1]
-    #                 rikolti_id = (
-    #                     f"{context.get('collection_id')}--oai:cca:{item_id}"
-    #                 )
-    #                 shimmed_ids[rikolti_id] = r
-    #             return shimmed_ids
-    #     elif type == "Solr":
-    #         return {r['harvest_id_s']: r for r in collection}
-
     @staticmethod
     def str_match_ignore_url_protocol(validation_def: dict,
                                     rikolti_value: Any,

--- a/metadata_mapper/mappers/oai/cca_vault_mapper.py
+++ b/metadata_mapper/mappers/oai/cca_vault_mapper.py
@@ -2,7 +2,7 @@ from typing import Union, Any
 
 from .oai_mapper import OaiRecord, OaiVernacular
 from ..mapper import Validator
-from ...validator import ValidationLogLevel
+from ...validator import ValidationLogLevel, ValidationMode
 
 
 class CcaVaultRecord(OaiRecord):
@@ -53,6 +53,38 @@ class CcaVaultValidator(Validator):
                 CcaVaultValidator.source_content_match,
             ],
             level=ValidationLogLevel.WARNING
+        )
+        self.add_validatable_field(
+            field="description", type=str,
+            validations=[CcaVaultValidator.description_match],
+            level=ValidationLogLevel.WARNING,
+        )
+        # these are all modified to indicate order doesn't matter with
+        # otherwise they're the same as the default validator
+        # validation_mode=ValidationMode.LAX
+        self.add_validatable_field(
+            field="temporal", type=str,
+            validations=[Validator.content_match],
+            level=ValidationLogLevel.WARNING,
+            validation_mode=ValidationMode.LAX
+        )
+        self.add_validatable_field(
+            field="date", type=str,
+            validations=[Validator.content_match],
+            level=ValidationLogLevel.WARNING,
+            validation_mode=ValidationMode.LAX
+        )
+        self.add_validatable_field(
+            field="creator", type=str,
+            validations=[Validator.content_match],
+            level=ValidationLogLevel.WARNING,
+            validation_mode=ValidationMode.LAX
+        )
+        self.add_validatable_field(
+            field="format", type=str,
+            validations=[Validator.content_match],
+            level=ValidationLogLevel.WARNING,
+            validation_mode=ValidationMode.LAX
         )
 
     # def generate_keys(self, collection: list[dict], type: str = None,
@@ -127,6 +159,15 @@ class CcaVaultValidator(Validator):
         else:
             return Validator.content_match(
                 validation_def, rikolti_value, comparison_value)
+
+    @staticmethod
+    def description_match(validation_def: dict, rikolti_value: Any,
+                          comparison_value: Any) -> None:
+        if not validation_def["validation_mode"].value.compare(
+            rikolti_value, comparison_value):
+            new_comparison_value = [v.rstrip("\n ") for v in comparison_value]
+            return Validator.content_match(
+                validation_def, rikolti_value, new_comparison_value)
 
 
 class CcaVaultVernacular(OaiVernacular):

--- a/metadata_mapper/mappers/oai/cca_vault_mapper.py
+++ b/metadata_mapper/mappers/oai/cca_vault_mapper.py
@@ -55,50 +55,50 @@ class CcaVaultValidator(Validator):
             level=ValidationLogLevel.WARNING
         )
 
-    def generate_keys(self, collection: list[dict], type: str = None,
-                      context: dict = {}) -> dict[str, dict]:
-        """
-        Given a list of records, generates keys and returns a dict with the
-        original list contents as values.
+    # def generate_keys(self, collection: list[dict], type: str = None,
+    #                   context: dict = {}) -> dict[str, dict]:
+    #     """
+    #     Given a list of records, generates keys and returns a dict with the
+    #     original list contents as values.
 
-        This can be used to override the creation of keys for a given
-        mapper to ensure that key intersection works in the
-        validate_mapping module.
+    #     This can be used to override the creation of keys for a given
+    #     mapper to ensure that key intersection works in the
+    #     validate_mapping module.
 
-        Parameters:
-            collection: list[dict]
-                Data to be added to resulting dict
-            type: str (default: None)
-                Optional context. Usually this will be used to tell
-                this method if it's dealing with Rikolti or Solr data.
-            context: dict (default: {})
-                Any information needed to perform these calculations.
+    #     Parameters:
+    #         collection: list[dict]
+    #             Data to be added to resulting dict
+    #         type: str (default: None)
+    #             Optional context. Usually this will be used to tell
+    #             this method if it's dealing with Rikolti or Solr data.
+    #         context: dict (default: {})
+    #             Any information needed to perform these calculations.
 
-        Returns: dict[str, dict]
-            dict of dicts, keyed to ensure successful intersection.
-        """
-        if type == "Rikolti":
-            # "oai:vault.cca.edu:" is new style, 3433 uses it
-            # "oai:cca:" is old style, 26470, 3767, 26391 use it
-            # example: 3433--oai:vault.cca.edu:006f6694-a826-6c83-b455-5b62a1ef9d69/1
-            # vs: 26470--oai:cca:0029e39d-c3f3-9346-a7d8-6565486a75a8/1
-            if context.get('collection_id') == '3433':
-                # do the usual thing
-                return {
-                    f"{context.get('collection_id')}--{r['calisphere-id']}": r
-                    for r in collection
-                }
-            else:
-                shimmed_ids = {}
-                for r in collection:
-                    item_id = r['calisphere-id'].split(':')[-1]
-                    rikolti_id = (
-                        f"{context.get('collection_id')}--oai:cca:{item_id}"
-                    )
-                    shimmed_ids[rikolti_id] = r
-                return shimmed_ids
-        elif type == "Solr":
-            return {r['harvest_id_s']: r for r in collection}
+    #     Returns: dict[str, dict]
+    #         dict of dicts, keyed to ensure successful intersection.
+    #     """
+    #     if type == "Rikolti":
+    #         # "oai:vault.cca.edu:" is new style, 3433 uses it
+    #         # "oai:cca:" is old style, 26470, 3767, 26391 use it
+    #         # example: 3433--oai:vault.cca.edu:006f6694-a826-6c83-b455-5b62a1ef9d69/1
+    #         # vs: 26470--oai:cca:0029e39d-c3f3-9346-a7d8-6565486a75a8/1
+    #         if context.get('collection_id') == '3433':
+    #             # do the usual thing
+    #             return {
+    #                 f"{context.get('collection_id')}--{r['calisphere-id']}": r
+    #                 for r in collection
+    #             }
+    #         else:
+    #             shimmed_ids = {}
+    #             for r in collection:
+    #                 item_id = r['calisphere-id'].split(':')[-1]
+    #                 rikolti_id = (
+    #                     f"{context.get('collection_id')}--oai:cca:{item_id}"
+    #                 )
+    #                 shimmed_ids[rikolti_id] = r
+    #             return shimmed_ids
+    #     elif type == "Solr":
+    #         return {r['harvest_id_s']: r for r in collection}
 
     @staticmethod
     def str_match_ignore_url_protocol(validation_def: dict,

--- a/metadata_mapper/mappers/oai/oai_mapper.py
+++ b/metadata_mapper/mappers/oai/oai_mapper.py
@@ -105,13 +105,24 @@ class OaiVernacular(Vernacular):
             if sickle_header.deleted:
                 continue
 
-            record = sickle_rec.metadata
+            record = self.strip_metadata(sickle_rec.metadata)
             record['datestamp'] = sickle_header.datestamp
             record['id'] = sickle_header.identifier
             record['request_url'] = request_url
             records.append(record)
 
         return self.get_records(records)
+
+    def strip_metadata(self, record_metadata):
+        stripped = {}
+        for key, value in record_metadata.items():
+            if isinstance(value, str):
+                value = value.strip()
+            elif isinstance(value, list):
+                value = [v.strip() if isinstance(v, str) else v for v in value]
+            stripped[key] = value
+
+        return stripped
 
     # lxml parser requires bytes input or XML fragments without declaration,
     # so use 'rb' mode

--- a/metadata_mapper/settings.py
+++ b/metadata_mapper/settings.py
@@ -24,6 +24,7 @@ SKIP_UNDEFINED_ENRICHMENTS = os.environ.get('SKIP_UNDEFINED_ENRICHMENTS', False)
 
 SOLR_URL = os.environ.get('UCLDC_SOLR_URL', False)
 SOLR_API_KEY = os.environ.get('UCLDC_SOLR_API_KEY', False)
+COUCH_URL = os.environ.get('UCLDC_COUCH_URL', False)
 
 def local_path(folder, collection_id):
     local_path = os.sep.join([

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -175,7 +175,7 @@ def couch_db_request(collection_id: int, field_name: str) -> list[dict[str, str]
 
     Returns: list[dict]
     """
-    url = "https://harvest-prd.cdlib.org/" \
+    url = f"{settings.COUCH_URL}/" \
         "couchdb/ucldc/_design/all_provider_docs/" \
         "_list/has_field_value/by_provider_name_wdoc" \
         f"?key=\"{collection_id}\"&field={field_name}"


### PR DESCRIPTION
@lthurston The TL;DR is that Calisphere IDs are complicated, but should you choose to run the CCA Vault validation locally, you should create a new working branch that merges this branch into any CCA Vault mapper refinements before running the validator in order to effectively compare legacy records with new records. 

------------------------------------------------------------------------------------------

And here's the long explanation of why 🔥Identifiers Are Complicated🔥 😱🤯🥵😮‍💨😵‍💫 

This is likely a meeting discussion at some point @bibliotechy and @barbarahui. I think we're unblocked on evaluating CIC's work for now though, and developing some Airflow tasks feels like the current pressing priority, so I'm leaving some super thorough notes here so we can pick it up later. Major thanks to @christinklez for catching this! 

------------------------------------------------------------------------------------------

The CCA Vault mapper is used for mapping [4 different collections](https://registry.cdlib.org/api/v1/rikoltifetcher/?format=json&mapper_type=cca_vault_oai_dc&ready_for_publication=true): 

- `3433`: [CCA/C Archives](https://calisphere.org/collections/3433/) - 492 items in Calisphere
- `3767`: [Capp Street Project Archive](https://calisphere.org/collections/3767/) - 69 items in Calisphere
- `26391`: [Artists' Books](https://calisphere.org/collections/26391/) - 1 item in Calisphere
- `26470`: [Hamaguchi Study Print Collection](https://calisphere.org/collections/26470/) - 790 items in Calisphere

Since `3767`, `26391`, and `26470` were last harvested to Calisphere, the underlying system ID (aka "Couch ID") has drifted. Collection `3433` seems to have been more recently re-harvested, so Calisphere has the "new version" system IDs for items in Collection `3433`. 

For example, let's take a look at the one item in `26391`:

| Couch ID | Calisphere ID |
| -------------|---------------|
| [`26391--oai:cca:17c06cc5-c419-4e77-9bdb-43c69e94b4cd/1`](https://harvest-stg.cdlib.org/couchdb/_utils/document.html?ucldc/26391--oai%3Acca%3A17c06cc5-c419-4e77-9bdb-43c69e94b4cd%2F1) | [`b18141c00b32b3daf476dbd591f4ebda`](https://calisphere.org/item/b18141c00b32b3daf476dbd591f4ebda/) |

Let's also take a look at an item from `3433`:

| Couch ID | Calisphere ID |
|-------------|---------------|
| [`3433--oai:vault.cca.edu:48da210f-7b65-416c-bbce-534f9c26e71d/1`](https://harvest-stg.cdlib.org/couchdb/_utils/document.html?ucldc/3433--oai%3Avault.cca.edu%3A48da210f-7b65-416c-bbce-534f9c26e71d%2F1) | [`1121aa2a86e4ada41ee84b481e2ef2e4`](https://calisphere.org/item/1121aa2a86e4ada41ee84b481e2ef2e4/) |

The old-style Couch IDs for the items from `3767`, `26391`, and `26470` include the prefix `oai:cca:`. The new-style Couch IDs for the items from `3433` include the prefix: `oai:vault.cca.edu:`. In Rikolti, the system ID for all items freshly re-harvested have this new-style prefix: `oai:vault.cca.edu`. Let's take a look at that same item from `26391`:

| Rikolti System ID | Calisphere ID |
| -------------|---------------|
| `26391--oai:vault.cca.edu:17c06cc5-c419-4e77-9bdb-43c69e94b4cd/1` | `d033252a8385893bee7ad81ea314c403` |

We use this system ID to pair up metadata records from the legacy system and Rikolti for comparison. This PR fakes the Rikolti IDs in order to make the new-style IDs look like the old-style IDs for these three collections for the sake of finding a comparable record and producing a validation report on that record. This is a temporary fake for the sake of generating a validation report - the code here does not actually change the Rikolti system ID. Due to this temporary fake, we are able to compare records from our legacy system to the Rikolti system - the validation report for 26391 shows:

| Harvest ID | Level | Field | Description | Expected Value | Actual Value |
| --- | --- | --- | --- | --- | --- |
| 26391--oai:cca:17c06cc5-c419-4e77-9bdb-43c69e94b4cd/1 | ERROR | Content mismatch | id | b18141c00b32b3daf476dbd591f4ebda | d033252a8385893bee7ad81ea314c403 |
| 26391--oai:cca:17c06cc5-c419-4e77-9bdb-43c69e94b4cd/1 | ERROR | Content mismatch | title | ['Crystals to Aden / Michel Bulteau ; translated by Pierre Joris'] | ['Crystals to Aden / Michel Bulteau ; translated by Pierre Joris.'] |
| 26391--oai:cca:17c06cc5-c419-4e77-9bdb-43c69e94b4cd/1 | ERROR | Required field is false, null, or empty | is_shown_by | https://vault.cca.edu/thumbs/17c06cc5-c419-4e77-9bdb-43c69e94b4cd/0/?gallery=preview | None |
| 26391--oai:cca:17c06cc5-c419-4e77-9bdb-43c69e94b4cd/1 | ERROR | Content mismatch | is_shown_by | https://vault.cca.edu/thumbs/17c06cc5-c419-4e77-9bdb-43c69e94b4cd/0/?gallery=preview | None |

We also use this system ID to generate the Calisphere ID. Since this PR fakes the Rikolti system IDs, but does not actually change the Rikolti system IDs, the Calisphere ID - which is an md5 hash of the system ID - is a new Calisphere ID. Therefore, in the validation reports for these three collections, we see a content mismatch report for every item, because the new Calisphere ID (generated based on the new-style system ID) does not match the old Calisphere ID (generated based on the old-style system ID). 

While this PR results in some noisy validation output (at least 1 line per record), it also unblocks us from otherwise evaluating the CCA Vault mapper for how it handles mapping all the other fields except this system ID and the Calisphere ID. 

Regarding the system ID and the Calisphere ID, we have a decision to make. I can see a number of solutions:
1) We re-harvest these collections now using the legacy system, and use the legacy system for managing the Calisphere ID redirects
2) We create a system for managing Calisphere ID redirects that will go into place with Rikolti
3) We modify the underlying system ID for these collections, rather than just faking it, so these Calisphere IDs remain the same as we move onto Rikolti
4) We take a hard look at Calisphere ID production in general, attempt to stabilize the Calisphere identifier space, remove the coupling of system ID to Calisphere ID, and create some tooling (and additional operator steps) to match up and modify re-harvested records to existing records, so identifiers are maintained at the record-level through re-harvest operations (rather than as a slew of redirects). 
5) We decide that persistent identifiers of Calisphere objects is not within Calisphere's scope of service? That seems bad. 

I did not see any entries in our existing redirect table for Collection 3433 - either it is a newer collection that was only harvested with the new style system IDs, or it was previously harvested and the old Calisphere IDs are lost (and any links pointing to those old Calisphere IDs are dead links now). 