### PR TITLE
breaking: update local env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,30 @@ python --version
 # > Python 3.9.15
 
 # create python virtual environment
-python -m venv ~/.venv/rikolti/
-source ~/.venv/rikolti/bin/activate
+python -m venv .venv/rikolti/
+source .venv/rikolti/bin/activate
 
 # install dependencies
-cd metadata_fetcher/
-pip install -r requirements.txt
-cd ../metadata_mapper/
-pip install -r requirements.txt
+pip install -r requirements_dev.txt
+
+# setup local environment variables
+cp env.example env.local
+vi env.local
 ```
 
 Currently, I only use one virtual environment, even though each folder located at the root of this repository represents an isolated component. If dependency conflicts are encountered, I'll wind up creating separate environments.
 
-Note: We tried using `sam local` to develop the app locally and found that the overhead makes for a clunky and slow process that doesn't offer advantages over the local virtualenv development setup described above. We are using AWS SAM to build and deploy the lambda applications, however ([see below](#deploying-using-aws-sam)).
+Similarly, I also only use one env.local as well. Rikolti fetches data to your local system and then maps that data. Set `FETCHER_DATA_DEST` to the URI where you would like Rikolti to store fetched data - Rikolti will create a folder (or s3 prefix)`vernacular_metadata` at this location. Set `MAPPER_DATA_SRC` to the URI where Rikolti can find a `vernacular_metadata` folder that contains the fetched data you're attempting to map. Set `MAPPER_DATA_DEST` to the URI where you would like Rikolti to store mapped data - Rikolti will create a folder (or s3 prefix) `mapped_metadata` at this location.
+
+For example, one way to configure `env.local` is:
+
+```
+FETCHER_DATA_DEST=file:///Users/awieliczka/Projects/rikolti_data
+MAPPER_DATA_SRC=$FETCHER_DATA_DEST
+MAPPER_DATA_DEST=$FETCHER_DATA_DEST
+```
+
+Each of these can be different locations, however. For example, if you're attempting to re-run a mapper locally off of previously fetched data stored on s3, you might set `MAPPER_DATA_SRC=s3://rikolti_data`.
 
 ### Docker
 

--- a/env.example
+++ b/env.example
@@ -1,0 +1,9 @@
+# metadata_fetcher
+export FETCHER_DATA_DEST=file:///usr/local/airflow/rikolti_data
+export NUXEO=             # Required to run the NuxeoFetcher
+export FLICKR_API_KEY=    # Required to run the FlickrFetcher
+
+# metadata_mapper
+export MAPPER_DATA_SRC=file:///usr/local/airflow/rikolti_data
+export MAPPER_DATA_DEST=file:///usr/local/airflow/rikolti_data
+export SKIP_UNDEFINED_ENRICHMENTS=True

--- a/env.example
+++ b/env.example
@@ -1,9 +1,14 @@
 # metadata_fetcher
 export FETCHER_DATA_DEST=file:///usr/local/airflow/rikolti_data
-export NUXEO=             # Required to run the NuxeoFetcher
-export FLICKR_API_KEY=    # Required to run the FlickrFetcher
+export NUXEO=                                                       # ask for a key - required to run the NuxeoFetcher
+export FLICKR_API_KEY=                                              # ask for a key - required to run the FlickrFetcher
 
 # metadata_mapper
 export MAPPER_DATA_SRC=file:///usr/local/airflow/rikolti_data
 export MAPPER_DATA_DEST=file:///usr/local/airflow/rikolti_data
 export SKIP_UNDEFINED_ENRICHMENTS=True
+
+# validator
+# export UCLDC_SOLR_URL="https://harvest-stg.cdlib.org/solr_api"    # this is solr stage
+export UCLDC_SOLR_URL="https://solr.calisphere.org/solr"            # this is solr prod
+export UCLDC_SOLR_API_KEY=                                          # ask for a key

--- a/metadata_fetcher/README.md
+++ b/metadata_fetcher/README.md
@@ -1,22 +1,27 @@
 Entry points:
 
-python lambda_function.py '{"collection_id": 26098, "harvest_type": "nuxeo", "harvest_data": {"harvest_extra_data": "/asset-library/UCI/SCA_SpecialCollections/MS-R016/Cochems", "url": "https://nuxeo.cdlib.org/Nuxeo/site/api/v1"}}'
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/?harvest_type=NUX&format=json"
+python -m metadata_fetcher.lambda_function '{"collection_id": 26098, "harvest_type": "nuxeo", "harvest_data": {"harvest_extra_data": "/asset-library/UCI/SCA_SpecialCollections/MS-R016/Cochems", "url": "https://nuxeo.cdlib.org/Nuxeo/site/api/v1"}}'
+
+python -m metadata_fetcher.lambda_function '{"collection_id": 26098, "harvest_type": "nuxeo", "harvest_data": {"harvest_extra_data": "/asset-library/UCI/SCA_SpecialCollections/MS-R016/Cochems", "url": "https://nuxeo.cdlib.org/Nuxeo/site/api/v1"}}'
+
+python -m metadata_fetcher.lambda_function '{"collection_id": 27364, "harvest_data": {"harvest_extra_data": "72157709037967781", "url": "http://example.edu"}, "harvest_type": "flickr", "rikolti_mapper_type": "flickr.sppl"}'
+
+python -m metadata_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/?harvest_type=NUX&format=json"
 
 Artist Books (complex image objects)
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/26147/?format=json"
+python -m metadata_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/26147/?format=json"
 
 Anthill (pdf objects)
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/26695/?format=json"
+python -m metadata_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/26695/?format=json"
 
 Viet Stories (complex multi-format objects)
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/36/?format=json"
+python -m metadata_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/36/?format=json"
 
 Nightingale (complex image)
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/76/?format=json"
+python -m metadata_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/76/?format=json"
 
 Halpern (simple & complex video objects)
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/27694/?format=json"
+python -m metadata_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/27694/?format=json"
 
 Ramicova (simple image objects)
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/26098/?format=json"
+python -m metadat_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/26098/?format=json"

--- a/metadata_fetcher/fetchers/Fetcher.py
+++ b/metadata_fetcher/fetchers/Fetcher.py
@@ -27,7 +27,7 @@ class Fetcher(object):
         self.harvest_type = params.get('harvest_type')
         self.collection_id = params.get('collection_id')
         self.write_page = params.get('write_page', 0)
-        bucket = settings.S3_BUCKET
+        bucket = settings.DATA_DEST["BUCKET"]
 
         self.s3_data = {
             "ACL": 'bucket-owner-full-control',
@@ -46,10 +46,8 @@ class Fetcher(object):
         f.write(page)
 
     def get_local_path(self):
-        parent_dir = os.sep.join(os.getcwd().split(os.sep)[:-1])
         local_path = os.sep.join([
-            parent_dir,
-            'rikolti_bucket',
+            settings.DATA_DEST["PATH"],
             'vernacular_metadata',
             str(self.collection_id),
         ])
@@ -91,7 +89,7 @@ class Fetcher(object):
         record_count = self.check_page(response)
         if record_count:
             content = self.aggregate_vernacular_content(response.text)
-            if settings.DATA_DEST == 'local':
+            if settings.DATA_DEST["STORE"] != 's3':
                 self.fetchtolocal(content)
             else:
                 self.fetchtos3(content)

--- a/metadata_fetcher/fetchers/nuxeo_fetcher.py
+++ b/metadata_fetcher/fetchers/nuxeo_fetcher.py
@@ -79,7 +79,7 @@ class NuxeoFetcher(Fetcher):
             }
 
         if self.nuxeo['query_type'] == 'children':
-            if settings.DATA_DEST == 'local':
+            if settings.DATA_DEST != 's3':
                 path = self.get_local_path()
                 children_path = os.path.join(path, "children")
                 if not os.path.exists(children_path):

--- a/metadata_fetcher/lambda_function.py
+++ b/metadata_fetcher/lambda_function.py
@@ -63,13 +63,14 @@ if __name__ == "__main__":
         description="Fetch metadata in the institution's vernacular")
     parser.add_argument('payload', help='json payload')
     args = parser.parse_args(sys.argv[1:])
+    payload = json.loads(args.payload)
 
     logging.basicConfig(
-        filename=f"fetch_collection_{args.payload.get('collection_id')}.log",
+        filename=f"fetch_collection_{payload.get('collection_id')}.log",
         encoding='utf-8',
         level=logging.DEBUG
     )
-    print(f"Starting to fetch collection {args.payload.get('collection_id')}")
-    fetch_collection(args.payload, {})
-    print(f"Finished fetching collection {args.payload.get('collection_id')}")
+    print(f"Starting to fetch collection {payload.get('collection_id')}")
+    fetch_collection(payload, {})
+    print(f"Finished fetching collection {payload.get('collection_id')}")
     sys.exit(0)

--- a/metadata_fetcher/settings.py
+++ b/metadata_fetcher/settings.py
@@ -1,16 +1,23 @@
 import logging
 import os
 
+from urllib.parse import urlparse
+
 from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
 
 load_dotenv()
 
-DATA_DEST = os.environ.get('FETCHER_DATA_DEST', 's3')
-S3_BUCKET = os.environ.get('S3_BUCKET', False)
 NUXEO_TOKEN = os.environ.get('NUXEO')
 FLICKR_API_KEY = os.environ.get('FLICKR_API_KEY')
+
+DATA_DEST_URL = os.environ.get("FETCHER_DATA_DEST", "file:///tmp/")
+DATA_DEST = {
+    "STORE": urlparse(DATA_DEST_URL).scheme,
+    "BUCKET": urlparse(DATA_DEST_URL).netloc,
+    "PATH": urlparse(DATA_DEST_URL).path
+}
 
 for key, value in os.environ.items():
     logger.debug(f"{key}={value}")

--- a/metadata_mapper/lambda_function.py
+++ b/metadata_mapper/lambda_function.py
@@ -93,7 +93,7 @@ def map_page(payload: Union[dict, str], context: dict = {}):
     mapped_records = source_metadata_records
 
     writer = UCLDCWriter(payload)
-    if settings.DATA_DEST == 'local':
+    if settings.DATA_DEST["STORE"] == 'file':
         writer.write_local_mapped_metadata(
             [record.to_dict() for record in mapped_records])
 
@@ -123,7 +123,7 @@ def map_page(payload: Union[dict, str], context: dict = {}):
     #                   for record in mapped_records]
 
     mapped_metadata = [record.to_dict() for record in mapped_records]
-    if settings.DATA_DEST == 'local':
+    if settings.DATA_DEST["STORE"] == 'file':
         writer.write_local_mapped_metadata(mapped_metadata)
     else:
         writer.write_s3_mapped_metadata([

--- a/metadata_mapper/lambda_shepherd.py
+++ b/metadata_mapper/lambda_shepherd.py
@@ -6,8 +6,11 @@ import sys
 import boto3
 import requests
 
+from urllib.parse import urlparse
+
 from . import settings, validate_mapping
 from .lambda_function import map_page
+from .mappers.mapper import Record
 
 
 def get_collection(collection_id):
@@ -21,9 +24,6 @@ def get_collection(collection_id):
 def check_for_missing_enrichments(collection):
     """Check for missing enrichments - used for development but
     could likely be removed in production?"""
-    from urllib.parse import urlparse
-
-    from mappers.mapper import Record
 
     not_yet_implemented = []
     collection_enrichments = (

--- a/metadata_mapper/lambda_shepherd.py
+++ b/metadata_mapper/lambda_shepherd.py
@@ -42,7 +42,7 @@ def check_for_missing_enrichments(collection):
 def get_vernacular_pages(collection_id):
     page_list = []
 
-    if settings.DATA_SRC == 'local':
+    if settings.DATA_SRC["STORE"] == 'file':
         vernacular_path = settings.local_path(
             'vernacular_metadata', collection_id)
         try:

--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -55,7 +55,7 @@ class Vernacular(ABC, object):
         self.page_filename = payload.get('page_filename')
 
     def get_api_response(self) -> dict:
-        if settings.DATA_SRC == 'local':
+        if settings.DATA_SRC["STORE"] == 'file':
             return self.get_local_api_response()
         else:
             return self.get_s3_api_response()

--- a/metadata_mapper/settings.py
+++ b/metadata_mapper/settings.py
@@ -1,21 +1,33 @@
 import os
 
+from urllib.parse import urlparse
+
 from dotenv import load_dotenv
 
 load_dotenv()
 
-DATA_SRC = os.environ.get('MAPPER_DATA_SRC', 's3')
-DATA_DEST = os.environ.get('MAPPER_DATA_DEST', 's3')
+DATA_SRC_URL = os.environ.get('MAPPER_DATA_SRC', 'file:///tmp/')
+DATA_SRC = {
+    "STORE": urlparse(DATA_SRC_URL).scheme,
+    "BUCKET": urlparse(DATA_SRC_URL).netloc,
+    "PATH": urlparse(DATA_SRC_URL).path
+}
+
+DATA_DEST_URL = os.environ.get('MAPPER_DATA_DEST', 'file:///tmp/')
+DATA_DEST = {
+    "STORE": urlparse(DATA_DEST_URL).scheme,
+    "BUCKET": urlparse(DATA_DEST_URL).netloc,
+    "PATH": urlparse(DATA_DEST_URL).path
+}
+
 SKIP_UNDEFINED_ENRICHMENTS = os.environ.get('SKIP_UNDEFINED_ENRICHMENTS', False)
 
 SOLR_URL = os.environ.get('UCLDC_SOLR_URL', False)
 SOLR_API_KEY = os.environ.get('UCLDC_SOLR_API_KEY', False)
 
 def local_path(folder, collection_id):
-    parent_dir = os.sep.join(os.getcwd().split(os.sep)[:-1])
     local_path = os.sep.join([
-        parent_dir,
-        'rikolti_bucket',
+        DATA_SRC["PATH"],
         folder,
         str(collection_id),
     ])

--- a/metadata_mapper/utilities.py
+++ b/metadata_mapper/utilities.py
@@ -28,11 +28,11 @@ def import_vernacular_reader(mapper_type):
     nuxeo       | nuxeo_mapper        | NuxeoVernacular
     content_dm  | content_dm_mapper   | ContentDmVernacular
     """
-    from mappers.mapper import Vernacular
+    from .mappers.mapper import Vernacular
     *mapper_parent_modules, snake_cased_mapper_name = mapper_type.split(".")
 
     mapper_module = importlib.import_module(
-        f"mappers.{'.'.join(mapper_parent_modules)}.{snake_cased_mapper_name}_mapper",
+        f".mappers.{'.'.join(mapper_parent_modules)}.{snake_cased_mapper_name}_mapper",
         package="metadata_mapper"
     )
 

--- a/metadata_mapper/utilities.py
+++ b/metadata_mapper/utilities.py
@@ -51,7 +51,7 @@ def get_files(directory: str, collection_id: int) -> list[str]:
     """
     Gets a list of filenames in a given directory.
     """
-    if settings.DATA_SRC == "local":
+    if settings.DATA_SRC["STORE"] == "file":
         path = settings.local_path(directory, collection_id)
         return [f for f in os.listdir(path)
                 if os.path.isfile(os.path.join(path, f))]
@@ -79,7 +79,7 @@ def read_from_bucket(directory: str, collection_id: int,
     Returns: str
         The file contents
     """
-    if settings.DATA_SRC == 'local':
+    if settings.DATA_SRC["STORE"] == 'file':
         page_path = os.sep.join([
             settings.local_path(directory, collection_id),
             str(file_name)
@@ -87,7 +87,7 @@ def read_from_bucket(directory: str, collection_id: int,
 
         with open(page_path, "r") as metadata_file:
             return metadata_file.read()
-    elif settings.DATA_SRC == 's3':
+    elif settings.DATA_SRC["STORE"] == 's3':
         s3 = boto3.resource('s3')
         bucket = 'rikolti'
         key = f"{directory}/{collection_id}/{file_name}"
@@ -133,7 +133,7 @@ def write_to_bucket(directory: str, collection_id: int,
     if isinstance(content, list) or isinstance(content, dict):
         content = json.dumps(content)
 
-    if settings.DATA_SRC == 'local':
+    if settings.DATA_SRC["STORE"] == 'file':
         dir_path = settings.local_path(directory, collection_id)
         if not os.path.exists(dir_path):
             os.makedirs(dir_path)
@@ -141,7 +141,7 @@ def write_to_bucket(directory: str, collection_id: int,
 
         with open(page_path, "a" if append else "w") as file:
             file.write(content)
-    elif settings.DATA_SRC == 's3':
+    elif settings.DATA_SRC["STORE"] == 's3':
         s3 = boto3.resource('s3')
         bucket = 'rikolti'
         key = f"{directory}/{collection_id}/{file_name}"


### PR DESCRIPTION
`FETCHER_DATA_DEST`, `MAPPER_DATA_DEST`, and `MAPPER_DATA_SRC` should now all be full url paths. If I want to keep the same directory structure as what was previously established, that means setting these env vars to look like this:

```
FETCHER_DATA_DEST=file:///Users/awieliczka/Projects/rikolti/rikolti_bucket
MAPPER_DATA_DEST=file:///Users/awieliczka/Projects/rikolti/rikolti_bucket
MAPPER_DATA_SRC=file:///Users/awieliczka/Projects/rikolti/rikolti_bucket
```

Though it's worth noting that you can now specify any directory as a target directory for storing fetched or mapped metadata files - you are no longer forced to keep files in this particular location. Rikolti will create a `vernacular_metadata/<collection_id>/` folder in the `FETCHER_DATA_DEST` location, and a `mapped_metadata/<collection_id>/` folder in the `MAPPER_DATA_DEST` location. `MAPPER_DATA_SRC` must be a folder containing a `vernacular_metadata/<collection_id>/` folder in order for the mapper to run. 

If I were to run this in a docker container, I might add to a Dockerfile:

```
volumes: 
    - "/Users/awieliczka/Projects/rikolti_data:/usr/local/airflow/rikolti_data"
```

And then set 

```
FETCHER_DATA_DEST=file:///usr/local/airflow/rikolti_data
MAPPER_DATA_DEST=file:///usr/local/airflow/rikolti_data
MAPPER_DATA_SRC=file:///usr/local/airflow/rikolti_data
```