### PR TITLE
Fetcher DAG development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ samconfig.toml
 /.cache
 /.local
 !/.github
+startup.sh
 
 __pycache__

--- a/README.md
+++ b/README.md
@@ -35,19 +35,30 @@ python --version
 # > Python 3.9.15
 
 # create python virtual environment
-python -m venv ~/.venv/rikolti/
-source ~/.venv/rikolti/bin/activate
+python -m venv .venv/rikolti/
+source .venv/rikolti/bin/activate
 
 # install dependencies
-cd metadata_fetcher/
-pip install -r requirements.txt
-cd ../metadata_mapper/
-pip install -r requirements.txt
+pip install -r requirements_dev.txt
+
+# setup local environment variables
+cp env.example env.local
+vi env.local
 ```
 
 Currently, I only use one virtual environment, even though each folder located at the root of this repository represents an isolated component. If dependency conflicts are encountered, I'll wind up creating separate environments.
 
-Note: We tried using `sam local` to develop the app locally and found that the overhead makes for a clunky and slow process that doesn't offer advantages over the local virtualenv development setup described above. We are using AWS SAM to build and deploy the lambda applications, however ([see below](#deploying-using-aws-sam)).
+Similarly, I also only use one env.local as well. Rikolti fetches data to your local system and then maps that data. Set `FETCHER_DATA_DEST` to the URI where you would like Rikolti to store fetched data - Rikolti will create a folder (or s3 prefix)`vernacular_metadata` at this location. Set `MAPPER_DATA_SRC` to the URI where Rikolti can find a `vernacular_metadata` folder that contains the fetched data you're attempting to map. Set `MAPPER_DATA_DEST` to the URI where you would like Rikolti to store mapped data - Rikolti will create a folder (or s3 prefix) `mapped_metadata` at this location.
+
+For example, one way to configure `env.local` is:
+
+```
+FETCHER_DATA_DEST=file:///Users/awieliczka/Projects/rikolti_data
+MAPPER_DATA_SRC=$FETCHER_DATA_DEST
+MAPPER_DATA_DEST=$FETCHER_DATA_DEST
+```
+
+Each of these can be different locations, however. For example, if you're attempting to re-run a mapper locally off of previously fetched data stored on s3, you might set `MAPPER_DATA_SRC=s3://rikolti_data`.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -125,12 +125,25 @@ git clone git@github.com:ucldc/aws-mwaa-local-runner.git
 Then, modify `aws-mwaa-local-runner/docker/.env`, setting the following env vars to wherever the directories live on your machine, for example:
 
 ```
-DAGS_HOME="/Users/username/dev/rikolti/dags"
+DAGS_HOME="/Users/username/dev/rikolti"
 PLUGINS_HOME="/Users/username/dev/rikolti/plugins"
 REQS_HOME="/Users/username/dev/rikolti/dags"
 STARTUP_HOME="/Users/username/dev/rikolti/dags"
+RIKOLTI_DATA_HOME="/Users/username/dev/rikolti_data"
 ```
 
-These env vars are used in the `aws-mwaa-local-runner/docker/docker-compose-local.yml` script (and other docker-compose scripts) to mount the relevant directories containing Airflow DAGs, requirements, and plugins files into the docker container.
+These env vars are used in the `aws-mwaa-local-runner/docker/docker-compose-local.yml` script (and other docker-compose scripts) to mount the relevant directories containing Airflow DAGs, requirements, plugin files, startup file, and Rikolti data destination into the docker container.
 
-Then, follow the instructions in the [README](https://github.com/ucldc/aws-mwaa-local-runner/#readme) to build the docker image, run the container, and do local development.
+Then, create the `startup.sh` file by running `cp env.example startup.sh`. Update the startup.sh file with Nuxeo, Flickr, and Solr keys as available, and make sure that the following three environment variables are set:
+
+```
+export FETCHER_DATA_DEST=file:///usr/local/airflow/rikolti_data
+export MAPPER_DATA_SRC=file:///usr/local/airflow/rikolti_data
+export MAPPER_DATA_DEST=file:///usr/local/airflow/rikolti_data
+```
+
+The folder located at `/usr/local/airflow/rikolti_data` on the docker container is mounted to `RIKOLTI_DATA_HOME`, set in `aws-mwaa-local-runner/docker/.env`.
+
+Finally, run `./mwaa-local-env build-image` to build the docker image, and `./mwaa-local-env start` to start the mwaa local environment.
+
+For more information on `mwaa-local-env`, look for instructions in the [ucldc/aws-mwaa-local-runner:README](https://github.com/ucldc/aws-mwaa-local-runner/#readme) to build the docker image, run the container, and do local development.

--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ git clone git@github.com:ucldc/aws-mwaa-local-runner.git
 Then, modify `aws-mwaa-local-runner/docker/.env`, setting the following env vars to wherever the directories live on your machine, for example:
 
 ```
-DAGS_HOME="/Users/username/dev/rikolti/airflow/dags"
-PLUGINS_HOME="/Users/username/dev/rikolti/airflow/plugins"
-REQS_HOME="/Users/username/dev/rikolti/airflow"
-STARTUP_HOME="/Users/username/dev/rikolti/airflow"
+DAGS_HOME="/Users/username/dev/rikolti/dags"
+PLUGINS_HOME="/Users/username/dev/rikolti/plugins"
+REQS_HOME="/Users/username/dev/rikolti/dags"
+STARTUP_HOME="/Users/username/dev/rikolti/dags"
 ```
 
 These env vars are used in the `aws-mwaa-local-runner/docker/docker-compose-local.yml` script (and other docker-compose scripts) to mount the relevant directories containing Airflow DAGs, requirements, and plugins files into the docker container.

--- a/dags/fetcher_dag.py
+++ b/dags/fetcher_dag.py
@@ -18,7 +18,8 @@ def fetch_collection_task(dag_run=None):
         "https://registry.cdlib.org/api/v1/"
         f"rikoltifetcher/{collection_id}/"
     )
-    resp.raise_for_status()    
+    resp.raise_for_status()
+
     fetch_report = fetch_collection(resp.json(), {})
 
     return True

--- a/dags/fetcher_dag.py
+++ b/dags/fetcher_dag.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+import requests
+
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+
+from metadata_fetcher.lambda_function import fetch_collection
+
+
+@task()
+def fetch_collection_task(dag_run=None):
+    if not dag_run:
+        return False
+
+    collection_id = dag_run.conf.get('collection_id')
+    resp = requests.get(
+        "https://registry.cdlib.org/api/v1/"
+        f"rikoltifetcher/{collection_id}/"
+    )
+    resp.raise_for_status()    
+    fetch_report = fetch_collection(resp.json(), {})
+
+    return True
+
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    params={'collection_id': Param(1, description="Collection ID to fetch")},
+    tags=["rikolti"],
+)
+def fetcher_dag():
+    fetch_collection_task()
+
+fetcher_dag()

--- a/dags/fetcher_dag.py
+++ b/dags/fetcher_dag.py
@@ -5,7 +5,7 @@ import requests
 from airflow.decorators import dag, task
 from airflow.models.param import Param
 
-from metadata_fetcher.lambda_function import fetch_collection
+from rikolti.metadata_fetcher.lambda_function import fetch_collection
 
 
 @task()

--- a/dags/fetcher_dag.py
+++ b/dags/fetcher_dag.py
@@ -13,7 +13,14 @@ def fetch_collection_task(dag_run=None):
     if not dag_run:
         return False
 
-    collection_id = dag_run.conf.get('collection_id')
+    # since this uses the dag_run method of getting parameters, the default
+    # param specified in the @dag decorator isn't used and must be specified
+    # again here. perhaps using the param method of getting parameters would
+    # be better? I'm not clear on when to use which method - see
+    # taskflow_sample_dag for 3 different methods to retrieve user-specified
+    # task parameters. 
+    collection_id = dag_run.conf.get('collection_id', 26284)
+
     resp = requests.get(
         "https://registry.cdlib.org/api/v1/"
         f"rikoltifetcher/{collection_id}/"
@@ -22,14 +29,14 @@ def fetch_collection_task(dag_run=None):
 
     fetch_report = fetch_collection(resp.json(), {})
 
-    return True
+    return fetch_report
 
 
 @dag(
     schedule=None,
     start_date=datetime(2023, 1, 1),
     catchup=False,
-    params={'collection_id': Param(1, description="Collection ID to fetch")},
+    params={'collection_id': Param(26284, description="Collection ID to fetch")},
     tags=["rikolti"],
 )
 def fetcher_dag():

--- a/dags/operator_sample_dag.py
+++ b/dags/operator_sample_dag.py
@@ -23,7 +23,7 @@ def requests_test(collection_id):
     tags=["test"],
 )
 def testing_dag():
-    test_requests = PythonOperator(
+    test_requests = PythonOperator(         # noqa: F841
         task_id="test_requests",
         python_callable=requests_test,
         op_kwargs={

--- a/dags/operator_sample_dag.py
+++ b/dags/operator_sample_dag.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from airflow.decorators import dag
+from airflow.models.param import Param
+from airflow.operators.python import PythonOperator
+import requests
+
+def requests_test(collection_id):
+    print(f"collection_id: {collection_id}")
+    resp = requests.get(
+        "https://registry.cdlib.org/api/v1/"
+        f"rikolticollection/{collection_id}/"
+    )
+    resp.raise_for_status()
+    print(resp.json().get('name'))
+
+    return True
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    params={'collection_id': Param(1, description="Collection ID")},
+    tags=["test"],
+)
+def testing_dag():
+    test_requests = PythonOperator(
+        task_id="test_requests",
+        python_callable=requests_test,
+        op_kwargs={
+            "collection_id": "{{ dag_run.conf['collection_id'] }}"
+        }
+    )
+
+testing_dag()

--- a/dags/requirements.txt
+++ b/dags/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/dags/requirements.txt
+++ b/dags/requirements.txt
@@ -1,2 +1,3 @@
 requests
 sickle
+python-dotenv

--- a/dags/requirements.txt
+++ b/dags/requirements.txt
@@ -1,1 +1,2 @@
 requests
+sickle

--- a/dags/startup.sh
+++ b/dags/startup.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-export ENVIRONMENT_STAGE="development"
-
-export FETCHER_DATA_DEST="file:///usr/local/airflow/rikolti_bucket"

--- a/dags/startup.sh
+++ b/dags/startup.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-echo "Printing Apache Airflow component"
-echo $MWAA_AIRFLOW_COMPONENT
 export ENVIRONMENT_STAGE="development"
+
+export FETCHER_DATA_DEST="file:///usr/local/airflow/rikolti_bucket"

--- a/dags/startup.sh
+++ b/dags/startup.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Printing Apache Airflow component"
+echo $MWAA_AIRFLOW_COMPONENT
+export ENVIRONMENT_STAGE="development"

--- a/dags/taskflow_sample_dag.py
+++ b/dags/taskflow_sample_dag.py
@@ -29,14 +29,7 @@ def taskflow_params(dag_run=None, params=None):
     collection_id = context.get('params', {}).get('collection_id')
     print(collection_id)
 
-    resp = requests.get(
-        "https://registry.cdlib.org/api/v1/"
-        f"rikolticollection/{collection_id}/"
-    )
-    resp.raise_for_status()
-    print(resp.json().get('name'))
-
-    return True
+    return collection_id
 
 @task()
 def taskflow_get_admin_variables():
@@ -52,7 +45,11 @@ def taskflow_get_admin_variables():
 
 @task()
 def taskflow_mkdir():
-    """ get env variables previously set """
+    """ we have permissions inside /airflow/, but nowhere else it seems """
+    if os.path.exists("/usr/local/airflow/rikolti_bucket/test_dir"):
+        os.remove("/usr/local/airflow/rikolti_bucket/test_dir/test2.txt")
+        os.rmdir("/usr/local/airflow/rikolti_bucket/test_dir")
+
     os.mkdir("/usr/local/airflow/rikolti_bucket/test_dir")
     with open("/usr/local/airflow/rikolti_bucket/test_dir/test2.txt", "w") as f:
         f.write("hi amy")

--- a/dags/taskflow_sample_dag.py
+++ b/dags/taskflow_sample_dag.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+from airflow.operators.python import get_current_context
+
+# from airflow.operators.python import PythonOperator
+import requests
+
+@task()
+def taskflow_test_requests(dag_run=None, params=None):
+    """ three ways to get dag run parameters """
+
+    if dag_run:
+        print(dag_run.conf.get('collection_id'))
+
+    if params:
+        print(params.get('collection_id'))
+
+    context = get_current_context()
+    collection_id = context.get('params', {}).get('collection_id')
+    print(collection_id)
+
+    resp = requests.get(
+        "https://registry.cdlib.org/api/v1/"
+        f"rikolticollection/{collection_id}/"
+    )
+    resp.raise_for_status()
+    print(resp.json().get('name'))
+
+    return True
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    params={
+        'collection_id': Param(1, description="Collection ID")
+    },
+    tags=["test"],
+)
+def taskflow_test_dag():
+    taskflow_test_requests()
+
+taskflow_test_dag()

--- a/dags/taskflow_sample_dag.py
+++ b/dags/taskflow_sample_dag.py
@@ -1,3 +1,5 @@
+import os
+
 from datetime import datetime
 from airflow.decorators import dag, task
 from airflow.models.param import Param
@@ -35,6 +37,19 @@ def taskflow_get_admin_variables():
     """ get admin variables from airflow """
     foo = Variable.get("AIRFLOW_TEST")
     print(foo)
+    os.environ["AIRFLOW_TEST"] = foo
+
+    boo = os.environ.get("AIRFLOW_TEST")
+    print(boo)
+
+    return True
+
+@task()
+def taskflow_mkdir():
+    """ get env variables previously set """
+    os.mkdir("/usr/local/airflow/rikolti_bucket/test_dir")
+    with open("/usr/local/airflow/rikolti_bucket/test_dir/test2.txt", "w") as f:
+        f.write("hi amy")
     return True
 
 @task()
@@ -56,6 +71,7 @@ def taskflow_write_to_disk():
 def taskflow_test_dag():
     taskflow_test_requests()
     taskflow_get_admin_variables()
+    taskflow_mkdir()
     taskflow_write_to_disk()
 
 taskflow_test_dag()

--- a/dags/taskflow_sample_dag.py
+++ b/dags/taskflow_sample_dag.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from airflow.decorators import dag, task
 from airflow.models.param import Param
+from airflow.models import Variable
 from airflow.operators.python import get_current_context
 
 # from airflow.operators.python import PythonOperator
@@ -29,6 +30,20 @@ def taskflow_test_requests(dag_run=None, params=None):
 
     return True
 
+@task()
+def taskflow_get_admin_variables():
+    """ get admin variables from airflow """
+    foo = Variable.get("AIRFLOW_TEST")
+    print(foo)
+    return True
+
+@task()
+def taskflow_write_to_disk():
+    """ write a file to disk """
+    with open("/usr/local/airflow/rikolti_bucket/test.txt", "w") as f:
+        f.write("hello world")
+    return True
+
 @dag(
     schedule=None,
     start_date=datetime(2023, 1, 1),
@@ -40,5 +55,7 @@ def taskflow_test_requests(dag_run=None, params=None):
 )
 def taskflow_test_dag():
     taskflow_test_requests()
+    taskflow_get_admin_variables()
+    taskflow_write_to_disk()
 
 taskflow_test_dag()

--- a/dags/taskflow_sample_dag.py
+++ b/dags/taskflow_sample_dag.py
@@ -10,7 +10,13 @@ from airflow.operators.python import get_current_context
 import requests
 
 @task()
-def taskflow_test_requests(dag_run=None, params=None):
+def taskflow_test_requests():
+    resp = requests.get("https://google.com")
+    resp.raise_for_status()
+    return resp.status_code
+
+@task()
+def taskflow_params(dag_run=None, params=None):
     """ three ways to get dag run parameters """
 
     if dag_run:
@@ -34,10 +40,10 @@ def taskflow_test_requests(dag_run=None, params=None):
 
 @task()
 def taskflow_get_admin_variables():
-    """ get admin variables from airflow """
-    foo = Variable.get("AIRFLOW_TEST")
-    print(foo)
-    os.environ["AIRFLOW_TEST"] = foo
+    """ get admin variables from airflow db """
+    airflow_test_env = Variable.get("AIRFLOW_TEST")
+    print(airflow_test_env)
+    os.environ["AIRFLOW_TEST"] = airflow_test_env
 
     boo = os.environ.get("AIRFLOW_TEST")
     print(boo)
@@ -59,6 +65,13 @@ def taskflow_write_to_disk():
         f.write("hello world")
     return True
 
+@task()
+def taskflow_get_env():
+    """ get env variables previously set """
+    startup_env = os.environ.get("ENVIRONMENT_STAGE")
+    print(startup_env)
+    return startup_env
+
 @dag(
     schedule=None,
     start_date=datetime(2023, 1, 1),
@@ -70,8 +83,10 @@ def taskflow_write_to_disk():
 )
 def taskflow_test_dag():
     taskflow_test_requests()
+    taskflow_params()
     taskflow_get_admin_variables()
     taskflow_mkdir()
     taskflow_write_to_disk()
+    taskflow_get_env()
 
 taskflow_test_dag()

--- a/env.example
+++ b/env.example
@@ -1,0 +1,14 @@
+# metadata_fetcher
+export FETCHER_DATA_DEST=file:///usr/local/airflow/rikolti_data
+export NUXEO=                                                       # ask for a key - required to run the NuxeoFetcher
+export FLICKR_API_KEY=                                              # ask for a key - required to run the FlickrFetcher
+
+# metadata_mapper
+export MAPPER_DATA_SRC=file:///usr/local/airflow/rikolti_data
+export MAPPER_DATA_DEST=file:///usr/local/airflow/rikolti_data
+export SKIP_UNDEFINED_ENRICHMENTS=True
+
+# validator
+# export UCLDC_SOLR_URL="https://harvest-stg.cdlib.org/solr_api"    # this is solr stage
+export UCLDC_SOLR_URL="https://solr.calisphere.org/solr"            # this is solr prod
+export UCLDC_SOLR_API_KEY=                                          # ask for a key

--- a/metadata_fetcher/README.md
+++ b/metadata_fetcher/README.md
@@ -1,22 +1,27 @@
 Entry points:
 
-python lambda_function.py '{"collection_id": 26098, "harvest_type": "nuxeo", "harvest_data": {"harvest_extra_data": "/asset-library/UCI/SCA_SpecialCollections/MS-R016/Cochems", "url": "https://nuxeo.cdlib.org/Nuxeo/site/api/v1"}}'
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/?harvest_type=NUX&format=json"
+python -m metadata_fetcher.lambda_function '{"collection_id": 26098, "harvest_type": "nuxeo", "harvest_data": {"harvest_extra_data": "/asset-library/UCI/SCA_SpecialCollections/MS-R016/Cochems", "url": "https://nuxeo.cdlib.org/Nuxeo/site/api/v1"}}'
+
+python -m metadata_fetcher.lambda_function '{"collection_id": 26098, "harvest_type": "nuxeo", "harvest_data": {"harvest_extra_data": "/asset-library/UCI/SCA_SpecialCollections/MS-R016/Cochems", "url": "https://nuxeo.cdlib.org/Nuxeo/site/api/v1"}}'
+
+python -m metadata_fetcher.lambda_function '{"collection_id": 27364, "harvest_data": {"harvest_extra_data": "72157709037967781", "url": "http://example.edu"}, "harvest_type": "flickr", "rikolti_mapper_type": "flickr.sppl"}'
+
+python -m metadata_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/?harvest_type=NUX&format=json"
 
 Artist Books (complex image objects)
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/26147/?format=json"
+python -m metadata_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/26147/?format=json"
 
 Anthill (pdf objects)
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/26695/?format=json"
+python -m metadata_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/26695/?format=json"
 
 Viet Stories (complex multi-format objects)
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/36/?format=json"
+python -m metadata_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/36/?format=json"
 
 Nightingale (complex image)
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/76/?format=json"
+python -m metadata_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/76/?format=json"
 
 Halpern (simple & complex video objects)
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/27694/?format=json"
+python -m metadata_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/27694/?format=json"
 
 Ramicova (simple image objects)
-python fetch_registry_collections.py "https://registry.cdlib.org/api/v1/rikoltifetcher/26098/?format=json"
+python -m metadat_fetcher.fetch_registry_collections "https://registry.cdlib.org/api/v1/rikoltifetcher/26098/?format=json"

--- a/metadata_fetcher/fetchers/Fetcher.py
+++ b/metadata_fetcher/fetchers/Fetcher.py
@@ -27,7 +27,7 @@ class Fetcher(object):
         self.harvest_type = params.get('harvest_type')
         self.collection_id = params.get('collection_id')
         self.write_page = params.get('write_page', 0)
-        bucket = settings.S3_BUCKET
+        bucket = settings.DATA_DEST["BUCKET"]
 
         self.s3_data = {
             "ACL": 'bucket-owner-full-control',
@@ -46,10 +46,8 @@ class Fetcher(object):
         f.write(page)
 
     def get_local_path(self):
-        parent_dir = os.sep.join(os.getcwd().split(os.sep)[:-1])
         local_path = os.sep.join([
-            parent_dir,
-            'rikolti_bucket',
+            settings.DATA_DEST["PATH"],
             'vernacular_metadata',
             str(self.collection_id),
         ])
@@ -91,7 +89,7 @@ class Fetcher(object):
         record_count = self.check_page(response)
         if record_count:
             content = self.aggregate_vernacular_content(response.text)
-            if settings.DATA_DEST == 'local':
+            if settings.DATA_DEST["STORE"] != 's3':
                 self.fetchtolocal(content)
             else:
                 self.fetchtos3(content)

--- a/metadata_fetcher/fetchers/nuxeo_fetcher.py
+++ b/metadata_fetcher/fetchers/nuxeo_fetcher.py
@@ -79,7 +79,7 @@ class NuxeoFetcher(Fetcher):
             }
 
         if self.nuxeo['query_type'] == 'children':
-            if settings.DATA_DEST == 'local':
+            if settings.DATA_DEST != 's3':
                 path = self.get_local_path()
                 children_path = os.path.join(path, "children")
                 if not os.path.exists(children_path):

--- a/metadata_fetcher/lambda_function.py
+++ b/metadata_fetcher/lambda_function.py
@@ -63,13 +63,14 @@ if __name__ == "__main__":
         description="Fetch metadata in the institution's vernacular")
     parser.add_argument('payload', help='json payload')
     args = parser.parse_args(sys.argv[1:])
+    payload = json.loads(args.payload)
 
     logging.basicConfig(
-        filename=f"fetch_collection_{args.payload.get('collection_id')}.log",
+        filename=f"fetch_collection_{payload.get('collection_id')}.log",
         encoding='utf-8',
         level=logging.DEBUG
     )
-    print(f"Starting to fetch collection {args.payload.get('collection_id')}")
-    fetch_collection(args.payload, {})
-    print(f"Finished fetching collection {args.payload.get('collection_id')}")
+    print(f"Starting to fetch collection {payload.get('collection_id')}")
+    fetch_collection(payload, {})
+    print(f"Finished fetching collection {payload.get('collection_id')}")
     sys.exit(0)

--- a/metadata_fetcher/lambda_function.py
+++ b/metadata_fetcher/lambda_function.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 def import_fetcher(harvest_type):
     fetcher_module = importlib.import_module(
-        f".fetchers.{harvest_type}_fetcher", package="metadata_fetcher")
+        f".fetchers.{harvest_type}_fetcher", package=__package__)
     fetcher_module_words = harvest_type.split('_')
     class_type = ''.join([word.capitalize() for word in fetcher_module_words])
     fetcher_class = getattr(fetcher_module, f"{class_type}Fetcher")

--- a/metadata_fetcher/settings.py
+++ b/metadata_fetcher/settings.py
@@ -1,16 +1,23 @@
 import logging
 import os
 
+from urllib.parse import urlparse
+
 from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
 
 load_dotenv()
 
-DATA_DEST = os.environ.get('FETCHER_DATA_DEST', 's3')
-S3_BUCKET = os.environ.get('S3_BUCKET', False)
 NUXEO_TOKEN = os.environ.get('NUXEO')
 FLICKR_API_KEY = os.environ.get('FLICKR_API_KEY')
+
+DATA_DEST_URL = os.environ.get("FETCHER_DATA_DEST", "file:///tmp/")
+DATA_DEST = {
+    "STORE": urlparse(DATA_DEST_URL).scheme,
+    "BUCKET": urlparse(DATA_DEST_URL).netloc,
+    "PATH": urlparse(DATA_DEST_URL).path
+}
 
 for key, value in os.environ.items():
     logger.debug(f"{key}={value}")

--- a/metadata_mapper/lambda_function.py
+++ b/metadata_mapper/lambda_function.py
@@ -25,7 +25,7 @@ def import_vernacular_reader(mapper_type):
 
     mapper_module = importlib.import_module(
         f".mappers.{'.'.join(mapper_parent_modules)}.{snake_cased_mapper_name}_mapper",
-        package="metadata_mapper"
+        package=__package__
     )
 
     mapper_type_words = snake_cased_mapper_name.split('_')

--- a/metadata_mapper/lambda_function.py
+++ b/metadata_mapper/lambda_function.py
@@ -93,7 +93,7 @@ def map_page(payload: Union[dict, str], context: dict = {}):
     mapped_records = source_metadata_records
 
     writer = UCLDCWriter(payload)
-    if settings.DATA_DEST == 'local':
+    if settings.DATA_DEST["STORE"] == 'file':
         writer.write_local_mapped_metadata(
             [record.to_dict() for record in mapped_records])
 
@@ -123,7 +123,7 @@ def map_page(payload: Union[dict, str], context: dict = {}):
     #                   for record in mapped_records]
 
     mapped_metadata = [record.to_dict() for record in mapped_records]
-    if settings.DATA_DEST == 'local':
+    if settings.DATA_DEST["STORE"] == 'file':
         writer.write_local_mapped_metadata(mapped_metadata)
     else:
         writer.write_s3_mapped_metadata([

--- a/metadata_mapper/lambda_shepherd.py
+++ b/metadata_mapper/lambda_shepherd.py
@@ -6,8 +6,11 @@ import sys
 import boto3
 import requests
 
+from urllib.parse import urlparse
+
 from . import settings, validate_mapping
 from .lambda_function import map_page
+from .mappers.mapper import Record
 
 
 def get_collection(collection_id):
@@ -21,9 +24,6 @@ def get_collection(collection_id):
 def check_for_missing_enrichments(collection):
     """Check for missing enrichments - used for development but
     could likely be removed in production?"""
-    from urllib.parse import urlparse
-
-    from mappers.mapper import Record
 
     not_yet_implemented = []
     collection_enrichments = (
@@ -42,7 +42,7 @@ def check_for_missing_enrichments(collection):
 def get_vernacular_pages(collection_id):
     page_list = []
 
-    if settings.DATA_SRC == 'local':
+    if settings.DATA_SRC["STORE"] == 'file':
         vernacular_path = settings.local_path(
             'vernacular_metadata', collection_id)
         try:

--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -55,7 +55,7 @@ class Vernacular(ABC, object):
         self.page_filename = payload.get('page_filename')
 
     def get_api_response(self) -> dict:
-        if settings.DATA_SRC == 'local':
+        if settings.DATA_SRC["STORE"] == 'file':
             return self.get_local_api_response()
         else:
             return self.get_s3_api_response()

--- a/metadata_mapper/mappers/oac/oac_mapper.py
+++ b/metadata_mapper/mappers/oac/oac_mapper.py
@@ -147,7 +147,7 @@ class OacRecord(Record):
             # vs. the custom fetching mark was doing
             ref_images = self.source_metadata.get('originalRecord', {}).get(
                 'reference-image', [])
-            if type(ref_images) == dict:
+            if type(ref_images) == dict:        # noqa: E721
                 ref_images = [ref_images]
             for obj in ref_images:
                 if max(int(obj.get('X')), int(obj.get('Y'))) > dim:

--- a/metadata_mapper/settings.py
+++ b/metadata_mapper/settings.py
@@ -1,21 +1,33 @@
 import os
 
+from urllib.parse import urlparse
+
 from dotenv import load_dotenv
 
 load_dotenv()
 
-DATA_SRC = os.environ.get('MAPPER_DATA_SRC', 's3')
-DATA_DEST = os.environ.get('MAPPER_DATA_DEST', 's3')
+DATA_SRC_URL = os.environ.get('MAPPER_DATA_SRC', 'file:///tmp/')
+DATA_SRC = {
+    "STORE": urlparse(DATA_SRC_URL).scheme,
+    "BUCKET": urlparse(DATA_SRC_URL).netloc,
+    "PATH": urlparse(DATA_SRC_URL).path
+}
+
+DATA_DEST_URL = os.environ.get('MAPPER_DATA_DEST', 'file:///tmp/')
+DATA_DEST = {
+    "STORE": urlparse(DATA_DEST_URL).scheme,
+    "BUCKET": urlparse(DATA_DEST_URL).netloc,
+    "PATH": urlparse(DATA_DEST_URL).path
+}
+
 SKIP_UNDEFINED_ENRICHMENTS = os.environ.get('SKIP_UNDEFINED_ENRICHMENTS', False)
 
 SOLR_URL = os.environ.get('UCLDC_SOLR_URL', False)
 SOLR_API_KEY = os.environ.get('UCLDC_SOLR_API_KEY', False)
 
 def local_path(folder, collection_id):
-    parent_dir = os.sep.join(os.getcwd().split(os.sep)[:-1])
     local_path = os.sep.join([
-        parent_dir,
-        'rikolti_bucket',
+        DATA_SRC["PATH"],
         folder,
         str(collection_id),
     ])

--- a/metadata_mapper/utilities.py
+++ b/metadata_mapper/utilities.py
@@ -33,7 +33,7 @@ def import_vernacular_reader(mapper_type):
 
     mapper_module = importlib.import_module(
         f".mappers.{'.'.join(mapper_parent_modules)}.{snake_cased_mapper_name}_mapper",
-        package="metadata_mapper"
+        package=__package__
     )
 
     mapper_type_words = snake_cased_mapper_name.split('_')

--- a/metadata_mapper/utilities.py
+++ b/metadata_mapper/utilities.py
@@ -28,11 +28,11 @@ def import_vernacular_reader(mapper_type):
     nuxeo       | nuxeo_mapper        | NuxeoVernacular
     content_dm  | content_dm_mapper   | ContentDmVernacular
     """
-    from mappers.mapper import Vernacular
+    from .mappers.mapper import Vernacular
     *mapper_parent_modules, snake_cased_mapper_name = mapper_type.split(".")
 
     mapper_module = importlib.import_module(
-        f"mappers.{'.'.join(mapper_parent_modules)}.{snake_cased_mapper_name}_mapper",
+        f".mappers.{'.'.join(mapper_parent_modules)}.{snake_cased_mapper_name}_mapper",
         package="metadata_mapper"
     )
 
@@ -51,7 +51,7 @@ def get_files(directory: str, collection_id: int) -> list[str]:
     """
     Gets a list of filenames in a given directory.
     """
-    if settings.DATA_SRC == "local":
+    if settings.DATA_SRC["STORE"] == "file":
         path = settings.local_path(directory, collection_id)
         return [f for f in os.listdir(path)
                 if os.path.isfile(os.path.join(path, f))]
@@ -79,7 +79,7 @@ def read_from_bucket(directory: str, collection_id: int,
     Returns: str
         The file contents
     """
-    if settings.DATA_SRC == 'local':
+    if settings.DATA_SRC["STORE"] == 'file':
         page_path = os.sep.join([
             settings.local_path(directory, collection_id),
             str(file_name)
@@ -87,7 +87,7 @@ def read_from_bucket(directory: str, collection_id: int,
 
         with open(page_path, "r") as metadata_file:
             return metadata_file.read()
-    elif settings.DATA_SRC == 's3':
+    elif settings.DATA_SRC["STORE"] == 's3':
         s3 = boto3.resource('s3')
         bucket = 'rikolti'
         key = f"{directory}/{collection_id}/{file_name}"
@@ -133,7 +133,7 @@ def write_to_bucket(directory: str, collection_id: int,
     if isinstance(content, list) or isinstance(content, dict):
         content = json.dumps(content)
 
-    if settings.DATA_SRC == 'local':
+    if settings.DATA_SRC["STORE"] == 'file':
         dir_path = settings.local_path(directory, collection_id)
         if not os.path.exists(dir_path):
             os.makedirs(dir_path)
@@ -141,7 +141,7 @@ def write_to_bucket(directory: str, collection_id: int,
 
         with open(page_path, "a" if append else "w") as file:
             file.write(content)
-    elif settings.DATA_SRC == 's3':
+    elif settings.DATA_SRC["STORE"] == 's3':
         s3 = boto3.resource('s3')
         bucket = 'rikolti'
         key = f"{directory}/{collection_id}/{file_name}"


### PR DESCRIPTION
This is a PR representing the work @barbarahui and I did in writing a first fetcher DAG. Since writing to s3 is not fully supported by the codebase, this work is coordinated with some updates to `ucldc/aws-mwaa-local-runner` described here: https://github.com/ucldc/aws-mwaa-local-runner/pull/3 and is built on top of the DATA_DEST environment variable work here: https://github.com/ucldc/rikolti/pull/495

This PR, in contrast to the DATA_DEST environment variable work, is exclusively DAG-specific work.

- `dags/operate_sample_dag.py` is a DAG written using the classic airflow PythonOperator. 
- `dags/taskflow_sample_dag.py` is a DAG written using the airflow taskflow model. This file also includes a variety of small tasks demonstrating specific, but relevant airflow features. 
- `dags/fetcher_dag.py` is a functional fetcher DAG. 

In order to run the fetcher DAG, you must have:

1. Pulled the `ucldc/aws-mwaa-local-runner:dags-development` branch
2. Modified the `aws-mwaa-local-runner/docker/.env` file:

```sh
# aws-mwaa-local-runner/docker/.env
DAGS_HOME="<path to this repository>/rikolti"
PLUGINS_HOME="<path to this repository>/rikolti/plugins"
REQS_HOME="<path to this repository>/rikolti/dags"
STARTUP_HOME="<path to this repository>/rikolti/dags"
RIKOLTI_DATA_HOME="<path to where you would like the fetcher to write data>"
```

3. Run `./mwaa-local-env build-image`
4. Write a startup.sh file in the `dags` folder:

```sh
# startup.sh
FETCHER_DATA_DEST=file:///usr/local/airflow/rikolti_data
MAPPER_DATA_DEST=file:///usr/local/airflow/rikolti_data
MAPPER_DATA_SRC=file:///usr/local/airflow/rikolti_data
```

5. Run `./mwaa-local-env start`