### PR TITLE
Validation report updates

### DIFF
--- a/metadata_mapper/lambda_shepherd.py
+++ b/metadata_mapper/lambda_shepherd.py
@@ -133,6 +133,8 @@ def map_collection(collection_id, validate=False):
     return {
         'status': 'success',
         'collection_id': collection_id,
+        'pre_mapping': collection.get('rikolti__pre_mapping'),
+        'enrichments': collection.get('rikolti__enrichments'),
         'missing_enrichments': check_for_missing_enrichments(collection),
         'records_mapped': collection_stats.get('count'),
         'pages_mapped': collection_stats.get('page_count'),

--- a/metadata_mapper/map_registry_collections.py
+++ b/metadata_mapper/map_registry_collections.py
@@ -56,13 +56,27 @@ def map_endpoint(url, limit=None):
             print(f"[{collection_id}]: not fetched yet", file=sys.stderr)
             continue
 
-        missing_enrichments = map_result.get('missing_enrichments')
+        pre_mapping = map_result.get('pre_mapping', [])
+        if len(pre_mapping) > 0:
+            print(
+                f"{collection_id}, pre-mapping enrichments, ",
+                f"ALL, -, -, \"{pre_mapping}\""
+            )
+
+        enrichments = map_result.get('enrichments', [])
+        if len(enrichments) > 0:
+            print(
+                f"{collection_id}, post-mapping enrichments, ",
+                f"ALL, -, -, \"{enrichments}\""
+            )
+
+        missing_enrichments = map_result.get('missing_enrichments', [])
         if len(missing_enrichments) > 0:
             print(
                 f"{collection_id}, missing enrichments, ",
-                f"ALL, -, -, {missing_enrichments}"
+                f"ALL, -, -, \"{missing_enrichments}\""
             )
-        exceptions = map_result.get('exceptions')
+        exceptions = map_result.get('exceptions', {})
         if len(exceptions) > 0:
             for exception, couch_ids in exceptions.items():
                 print(
@@ -73,7 +87,6 @@ def map_endpoint(url, limit=None):
                     f"{collection_id}, enrichment error records, "
                     f'{len(couch_ids)}, -, -, "{couch_ids}"'
                 )
-
 
         # "Collection ID, Status, Extent, Solr Count, Diff Count, Message"
         success = 'success' if map_result['status'] == 'success' else 'error'

--- a/metadata_mapper/validator/validation_log.py
+++ b/metadata_mapper/validator/validation_log.py
@@ -19,7 +19,13 @@ class ValidationLog:
         "field": "Field",
         "description": "Description",
         "expected": "Expected Value",
-        "actual": "Actual Value"
+        "actual": "Actual Value",
+        "calisphere_prd": "Calisphere Production",
+        "solr_prd": "Solr Production",
+        "couch_prd": "Couch Production",
+        "calisphere_test": "Calisphere Test",
+        "solr_stg": "Solr Stage",
+        "couch_stg": "Couch Stage",
     }
 
     def __init__(self, log_level: ValidationLogLevel = ValidationLogLevel.WARNING):


### PR DESCRIPTION
- Adds links to calisphere, solr-prd, couch-prd, calisphere-test, solr-stg, and couch-stg to items appearing in the validation report
- Adds pre-mapping and post-mapping enrichment chain data to mapper job output