### PR TITLE
Inputs outputs logs

### DIFF
--- a/dags/fetcher_dag.py
+++ b/dags/fetcher_dag.py
@@ -7,6 +7,7 @@ from rikolti.dags.harvest_dag import get_collection_fetchdata_task
 from rikolti.dags.harvest_dag import fetch_collection_task
 
 @dag(
+    dag_id="fetch_collection",
     schedule=None,
     start_date=datetime(2023, 1, 1),
     catchup=False,

--- a/dags/fetcher_dag.py
+++ b/dags/fetcher_dag.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from airflow.decorators import dag
 from airflow.models.param import Param
 
-
+from rikolti.dags.harvest_dag import get_collection_fetchdata_task
 from rikolti.dags.harvest_dag import fetch_collection_task
 
 @dag(
@@ -14,6 +14,7 @@ from rikolti.dags.harvest_dag import fetch_collection_task
     tags=["rikolti"],
 )
 def fetcher_dag():
-    fetch_collection_task()
+    fetchdata = get_collection_fetchdata_task()
+    fetch_report = fetch_collection_task(collection=fetchdata)
 
 fetcher_dag()

--- a/dags/fetcher_dag.py
+++ b/dags/fetcher_dag.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from airflow.decorators import dag
 from airflow.models.param import Param
 
-from rikolti.dags.harvest_dag import get_collection_fetchdata_task
-from rikolti.dags.harvest_dag import fetch_collection_task
+from rikolti.dags.shared_tasks import get_collection_fetchdata_task
+from rikolti.dags.shared_tasks import fetch_collection_task
 
 @dag(
     dag_id="fetch_collection",

--- a/dags/fetcher_dag.py
+++ b/dags/fetcher_dag.py
@@ -1,29 +1,10 @@
 from datetime import datetime
 
-import requests
-
-from airflow.decorators import dag, task
+from airflow.decorators import dag
 from airflow.models.param import Param
 
-from rikolti.metadata_fetcher.lambda_function import fetch_collection
 
-
-@task()
-def fetch_collection_task(params=None):
-    if not params or not params.get('collection_id'):
-        return False
-    collection_id = params.get('collection_id')
-
-    resp = requests.get(
-        "https://registry.cdlib.org/api/v1/"
-        f"rikoltifetcher/{collection_id}/?format=json"
-    )
-    resp.raise_for_status()
-
-    fetch_report = fetch_collection(resp.json(), {})
-
-    return fetch_report
-
+from rikolti.dags.harvest_dag import fetch_collection_task
 
 @dag(
     schedule=None,

--- a/dags/fetcher_dag.py
+++ b/dags/fetcher_dag.py
@@ -15,6 +15,6 @@ from rikolti.dags.harvest_dag import fetch_collection_task
 )
 def fetcher_dag():
     fetchdata = get_collection_fetchdata_task()
-    fetch_report = fetch_collection_task(collection=fetchdata)
+    fetched_pages = fetch_collection_task(collection=fetchdata)
 
 fetcher_dag()

--- a/dags/fetcher_dag.py
+++ b/dags/fetcher_dag.py
@@ -15,6 +15,6 @@ from rikolti.dags.harvest_dag import fetch_collection_task
 )
 def fetcher_dag():
     fetchdata = get_collection_fetchdata_task()
-    fetched_pages = fetch_collection_task(collection=fetchdata)
+    fetch_collection_task(collection=fetchdata)
 
 fetcher_dag()

--- a/dags/fetcher_dag.py
+++ b/dags/fetcher_dag.py
@@ -9,21 +9,14 @@ from rikolti.metadata_fetcher.lambda_function import fetch_collection
 
 
 @task()
-def fetch_collection_task(dag_run=None):
-    if not dag_run:
+def fetch_collection_task(params=None):
+    if not params or not params.get('collection_id'):
         return False
-
-    # since this uses the dag_run method of getting parameters, the default
-    # param specified in the @dag decorator isn't used and must be specified
-    # again here. perhaps using the param method of getting parameters would
-    # be better? I'm not clear on when to use which method - see
-    # taskflow_sample_dag for 3 different methods to retrieve user-specified
-    # task parameters. 
-    collection_id = dag_run.conf.get('collection_id', 26284)
+    collection_id = params.get('collection_id')
 
     resp = requests.get(
         "https://registry.cdlib.org/api/v1/"
-        f"rikoltifetcher/{collection_id}/"
+        f"rikoltifetcher/{collection_id}/?format=json"
     )
     resp.raise_for_status()
 
@@ -36,7 +29,7 @@ def fetch_collection_task(dag_run=None):
     schedule=None,
     start_date=datetime(2023, 1, 1),
     catchup=False,
-    params={'collection_id': Param(26284, description="Collection ID to fetch")},
+    params={'collection_id': Param(None, description="Collection ID to fetch")},
     tags=["rikolti"],
 )
 def fetcher_dag():

--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -99,7 +99,7 @@ def get_mapping_status_task(collection: dict, mapped_pages: list):
     schedule=None,
     start_date=datetime(2023, 1, 1),
     catchup=False,
-    params={'collection_id': Param(3433, description="Collection ID to map")},
+    params={'collection_id': Param(None, description="Collection ID to map")},
     tags=["rikolti"],
 )
 def harvest():

--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -1,97 +1,15 @@
-import requests
 from datetime import datetime
 
-from airflow.decorators import dag, task
+from airflow.decorators import dag
 from airflow.models.param import Param
 
-from rikolti.metadata_fetcher.lambda_function import fetch_collection
-from rikolti.metadata_mapper.lambda_function import map_page
-from rikolti.metadata_mapper.lambda_shepherd import get_mapping_status
 
+from rikolti.dags.shared_tasks import fetch_collection_task
+from rikolti.dags.shared_tasks import get_collection_fetchdata_task
+from rikolti.dags.shared_tasks import get_collection_metadata_task
+from rikolti.dags.shared_tasks  import map_page_task
+from rikolti.dags.shared_tasks  import get_mapping_status_task
 
-# TODO: remove the rikoltifetcher registry endpoint and restructure
-# the fetch_collection function to accept a rikolticollection resource.
-@task()
-def get_collection_fetchdata_task(params=None):
-    if not params or not params.get('collection_id'):
-        raise ValueError("Collection ID not found in params")
-    collection_id = params.get('collection_id')
-
-    resp = requests.get(
-        "https://registry.cdlib.org/api/v1/"
-        f"rikoltifetcher/{collection_id}/?format=json"
-    )
-    resp.raise_for_status()
-
-    return resp.json()
-
-
-@task()
-def fetch_collection_task(collection: dict):
-    fetch_status = fetch_collection(collection, {})
-
-    success = all([page['status'] == 'success' for page in fetch_status])
-    total_items = sum([page['document_count'] for page in fetch_status])
-    total_pages = fetch_status[-1]['page'] + 1
-    diff_items = total_items - collection['solr_count']
-    date = datetime.strptime(
-        collection['solr_last_updated'],
-        "%Y-%m-%dT%H:%M:%S.%f"
-    )
-
-    print(
-        f"{'Successfully fetched' if success else 'Error fetching'} "
-        f"collection {collection['collection_id']}"
-    )
-    print(
-        f"Fetched {total_items} items across {total_pages} pages "
-        f"at a rate of ~{total_items / total_pages} items per page"
-    )
-    print(
-        f"As of {datetime.strftime(date, '%B %d, %Y %H:%M:%S.%f')} "
-        f"Solr has {collection['solr_count']} items"
-    )
-    if diff_items != 0:
-        print(
-            f"Rikolti fetched {abs(diff_items)} "
-            f"{'more' if diff_items > 0 else 'fewer'} items."
-        )
-
-    return [
-        str(page['page']) for page in fetch_status if page['status']=='success'
-    ]
-
-
-@task()
-def get_collection_metadata_task(params=None):
-    if not params or not params.get('collection_id'):
-        raise ValueError("Collection ID not found in params")
-    collection_id = params.get('collection_id')
-
-    resp = requests.get(
-        "https://registry.cdlib.org/api/v1/"
-        f"rikolticollection/{collection_id}/?format=json"
-    )
-    resp.raise_for_status()
-
-    return resp.json()
-
-
-# max_active_tis_per_dag - setting on the task to restrict how many
-# instances can be running at the same time, *across all DAG runs*
-@task()
-def map_page_task(page: str, collection: dict):
-    collection_id = collection.get('id')
-    if not collection_id:
-        return False
-    mapped_page = map_page(collection_id, page, collection)
-    return mapped_page
-
-
-@task()
-def get_mapping_status_task(collection: dict, mapped_pages: list):
-    mapping_status = get_mapping_status(collection, mapped_pages)
-    return mapping_status
 
 
 @dag(

--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -1,13 +1,12 @@
 import requests
 from datetime import datetime
 
-from airflow.decorators import dag, task_group, task
+from airflow.decorators import dag, task
 from airflow.models.param import Param
 
 from rikolti.metadata_fetcher.lambda_function import fetch_collection
 from rikolti.metadata_mapper.lambda_function import map_page
-from rikolti.metadata_mapper.lambda_shepherd import \
-    get_mapping_status, check_for_missing_enrichments
+from rikolti.metadata_mapper.lambda_shepherd import get_mapping_status
 
 
 # TODO: remove the rikoltifetcher registry endpoint and restructure

--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -95,6 +95,7 @@ def get_mapping_status_task(collection: dict, mapped_pages: list):
 
 
 @dag(
+    dag_id="harvest_collection",
     schedule=None,
     start_date=datetime(2023, 1, 1),
     catchup=False,

--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -98,7 +98,7 @@ def get_mapping_status_task(collection: dict, mapped_pages: list):
     schedule=None,
     start_date=datetime(2023, 1, 1),
     catchup=False,
-    params={'collection_id': Param(None, description="Collection ID to map")},
+    params={'collection_id': Param(None, description="Collection ID to harvest")},
     tags=["rikolti"],
 )
 def harvest():

--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -1,0 +1,111 @@
+import requests
+
+from datetime import datetime
+
+from airflow.decorators import dag, task_group, task
+from airflow.models.param import Param
+
+from rikolti.metadata_fetcher.lambda_function import fetch_collection
+from rikolti.metadata_mapper.lambda_shepherd import get_vernacular_pages
+from rikolti.metadata_mapper.lambda_function import map_page
+from rikolti.metadata_mapper.lambda_shepherd import \
+    get_mapping_summary, check_for_missing_enrichments
+
+
+@task()
+def fetch_collection_task(params=None):
+    if not params or not params.get('collection_id'):
+        return False
+    collection_id = params.get('collection_id')
+
+    resp = requests.get(
+        "https://registry.cdlib.org/api/v1/"
+        f"rikoltifetcher/{collection_id}/?format=json"
+    )
+    resp.raise_for_status()
+
+    fetch_report = fetch_collection(resp.json(), {})
+
+    return fetch_report
+
+
+@task()
+def get_collection_metadata_task(params=None):
+    if not params or not params.get('collection_id'):
+        return False
+    collection_id = params.get('collection_id')
+
+    resp = requests.get(
+        "https://registry.cdlib.org/api/v1/"
+        f"rikolticollection/{collection_id}/?format=json"
+    )
+    resp.raise_for_status()
+
+    return resp.json()
+
+
+@task()
+def get_vernacular_pages_task(collection: dict):
+    collection_id = collection.get('id')
+    if not collection_id:
+        raise ValueError(
+            f"Collection ID not found in collection metadata: {collection}")
+    pages = get_vernacular_pages(collection_id)
+    return pages
+
+
+# max_active_tis_per_dag - setting on the task to restrict how many
+# instances can be running at the same time, *across all DAG runs*
+@task()
+def map_page_task(page: str, collection: dict):
+    collection_id = collection.get('id')
+    if not collection_id:
+        return False
+    mapped_page = map_page(collection_id, page, collection)
+    return mapped_page
+
+
+@task()
+def get_mapping_summary_task(mapped_pages: list, collection: dict):
+    collection_id = collection.get('id')
+    collection_summary = get_mapping_summary(mapped_pages)
+
+    return {
+        'status': 'success',
+        'collection_id': collection_id,
+        'pre_mapping': collection.get('rikolti__pre_mapping'),
+        'enrichments': collection.get('rikolti__enrichments'),
+        'missing_enrichments': check_for_missing_enrichments(collection),
+        'records_mapped': collection_summary.get('count'),
+        'pages_mapped': collection_summary.get('page_count'),
+        'exceptions': collection_summary.get('group_exceptions')
+    }
+
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    params={'collection_id': Param(None, description="Collection ID to map")},
+    tags=["rikolti"],
+)
+def harvest():
+    collection = get_collection_metadata_task()
+
+    @task_group(group_id="fetching")
+    def fetching(collection):
+        fetch_report = fetch_collection_task()
+
+    @task_group(group_id="mapping")
+    def mapping(collection):
+        page_list = get_vernacular_pages_task(collection=collection)
+        mapped_pages = (
+            map_page_task
+                .partial(collection=collection)
+                .expand(page=page_list)
+        )
+        get_mapping_summary_task(mapped_pages, collection)
+    
+    fetching(collection) >> mapping(collection)
+
+harvest()

--- a/dags/mapper_dag.py
+++ b/dags/mapper_dag.py
@@ -4,7 +4,7 @@ from airflow.decorators import dag, task
 from airflow.models.param import Param
 from rikolti.dags.harvest_dag import get_collection_metadata_task
 from rikolti.dags.harvest_dag import map_page_task
-from rikolti.dags.harvest_dag import get_mapping_summary_task
+from rikolti.dags.harvest_dag import get_mapping_status_task
 from rikolti.metadata_mapper.lambda_shepherd import get_vernacular_pages
 
 
@@ -48,5 +48,5 @@ def mapper_dag():
             .expand(page=page_list)
     )
 
-    get_mapping_summary_task(mapped_pages, collection)
+    get_mapping_status_task(collection, mapped_pages)
 mapper_dag()

--- a/dags/mapper_dag.py
+++ b/dags/mapper_dag.py
@@ -33,6 +33,7 @@ def get_vernacular_pages_task(collection: dict):
 # will fail - need to somehow chunk up pages into groups of 1024?
 
 @dag(
+    dag_id="map_collection",
     schedule=None,
     start_date=datetime(2023, 1, 1),
     catchup=False,

--- a/dags/mapper_dag.py
+++ b/dags/mapper_dag.py
@@ -2,9 +2,10 @@ from datetime import datetime
 
 from airflow.decorators import dag, task
 from airflow.models.param import Param
-from rikolti.dags.harvest_dag import get_collection_metadata_task
-from rikolti.dags.harvest_dag import map_page_task
-from rikolti.dags.harvest_dag import get_mapping_status_task
+
+from rikolti.dags.shared_tasks import get_collection_metadata_task
+from rikolti.dags.shared_tasks import map_page_task
+from rikolti.dags.shared_tasks import get_mapping_status_task
 from rikolti.metadata_mapper.lambda_shepherd import get_vernacular_pages
 
 

--- a/dags/mapper_dag.py
+++ b/dags/mapper_dag.py
@@ -1,11 +1,21 @@
 from datetime import datetime
 
-from airflow.decorators import dag
+from airflow.decorators import dag, task
 from airflow.models.param import Param
 from rikolti.dags.harvest_dag import get_collection_metadata_task
-from rikolti.dags.harvest_dag import get_vernacular_pages_task
 from rikolti.dags.harvest_dag import map_page_task
 from rikolti.dags.harvest_dag import get_mapping_summary_task
+from rikolti.metadata_mapper.lambda_shepherd import get_vernacular_pages
+
+
+@task()
+def get_vernacular_pages_task(collection: dict):
+    collection_id = collection.get('id')
+    if not collection_id:
+        raise ValueError(
+            f"Collection ID not found in collection metadata: {collection}")
+    pages = get_vernacular_pages(collection_id)
+    return pages
 
 # This is a functional duplicate of 
 # rikolti.metadata_mapper.lambda_shepherd.map_collection

--- a/dags/mapper_dag.py
+++ b/dags/mapper_dag.py
@@ -1,67 +1,11 @@
-import requests
-
 from datetime import datetime
 
-from airflow.decorators import dag, task
+from airflow.decorators import dag
 from airflow.models.param import Param
-from rikolti.metadata_mapper.lambda_shepherd import \
-    get_vernacular_pages, get_mapping_summary, \
-    check_for_missing_enrichments
-from rikolti.metadata_mapper.lambda_function import map_page
-
-
-@task()
-def get_collection_metadata_task(params=None):
-    if not params or not params.get('collection_id'):
-        return False
-    collection_id = params.get('collection_id')
-
-    resp = requests.get(
-        "https://registry.cdlib.org/api/v1/"
-        f"rikolticollection/{collection_id}/?format=json"
-    )
-    resp.raise_for_status()
-
-    return resp.json()
-
-
-@task()
-def get_vernacular_pages_task(collection: dict):
-    collection_id = collection.get('id')
-    if not collection_id:
-        raise ValueError(
-            f"Collection ID not found in collection metadata: {collection}")
-    pages = get_vernacular_pages(collection_id)
-    return pages
-
-
-# max_active_tis_per_dag - setting on the task to restrict how many
-# instances can be running at the same time, *across all DAG runs*
-@task()
-def map_page_task(page: str, collection: dict):
-    collection_id = collection.get('id')
-    if not collection_id:
-        return False
-    mapped_page = map_page(collection_id, page, collection)
-    return mapped_page
-
-
-@task()
-def get_mapping_summary_task(mapped_pages: list, collection: dict):
-    collection_id = collection.get('id')
-    collection_summary = get_mapping_summary(mapped_pages)
-
-    return {
-        'status': 'success',
-        'collection_id': collection_id,
-        'pre_mapping': collection.get('rikolti__pre_mapping'),
-        'enrichments': collection.get('rikolti__enrichments'),
-        'missing_enrichments': check_for_missing_enrichments(collection),
-        'records_mapped': collection_summary.get('count'),
-        'pages_mapped': collection_summary.get('page_count'),
-        'exceptions': collection_summary.get('group_exceptions')
-    }
-
+from rikolti.dags.harvest_dag import get_collection_metadata_task
+from rikolti.dags.harvest_dag import get_vernacular_pages_task
+from rikolti.dags.harvest_dag import map_page_task
+from rikolti.dags.harvest_dag import get_mapping_summary_task
 
 # This is a functional duplicate of 
 # rikolti.metadata_mapper.lambda_shepherd.map_collection

--- a/dags/mapper_dag.py
+++ b/dags/mapper_dag.py
@@ -4,8 +4,9 @@ from datetime import datetime
 
 from airflow.decorators import dag, task
 from airflow.models.param import Param
-from rikolti.metadata_mapper.lambda_shepherd import (get_vernacular_pages,
-    get_mapping_summary, check_for_missing_enrichments)
+from rikolti.metadata_mapper.lambda_shepherd import \
+    get_vernacular_pages, get_mapping_summary, \
+    check_for_missing_enrichments
 from rikolti.metadata_mapper.lambda_function import map_page
 
 
@@ -26,9 +27,10 @@ def get_collection_metadata_task(params=None):
 
 @task()
 def get_vernacular_pages_task(collection: dict):
-    collection_id = collection.get('collection_id')
+    collection_id = collection.get('id')
     if not collection_id:
-        return False
+        raise ValueError(
+            f"Collection ID not found in collection metadata: {collection}")
     pages = get_vernacular_pages(collection_id)
     return pages
 
@@ -37,7 +39,7 @@ def get_vernacular_pages_task(collection: dict):
 # instances can be running at the same time, *across all DAG runs*
 @task()
 def map_page_task(page: str, collection: dict):
-    collection_id = collection.get('collection_id')
+    collection_id = collection.get('id')
     if not collection_id:
         return False
     mapped_page = map_page(collection_id, page, collection)
@@ -46,7 +48,7 @@ def map_page_task(page: str, collection: dict):
 
 @task()
 def get_mapping_summary_task(mapped_pages: list, collection: dict):
-    collection_id = collection.get('collection_id')
+    collection_id = collection.get('id')
     collection_summary = get_mapping_summary(mapped_pages)
 
     return {

--- a/dags/shared_tasks.py
+++ b/dags/shared_tasks.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+
+import requests
+from airflow.decorators import task
+
+from rikolti.metadata_fetcher.lambda_function import fetch_collection
+from rikolti.metadata_mapper.lambda_function import map_page
+from rikolti.metadata_mapper.lambda_shepherd import get_mapping_status
+
+
+# TODO: remove the rikoltifetcher registry endpoint and restructure
+# the fetch_collection function to accept a rikolticollection resource.
+@task()
+def get_collection_fetchdata_task(params=None):
+    if not params or not params.get('collection_id'):
+        raise ValueError("Collection ID not found in params")
+    collection_id = params.get('collection_id')
+
+    resp = requests.get(
+        "https://registry.cdlib.org/api/v1/"
+        f"rikoltifetcher/{collection_id}/?format=json"
+    )
+    resp.raise_for_status()
+
+    return resp.json()
+
+
+@task()
+def fetch_collection_task(collection: dict):
+    fetch_status = fetch_collection(collection, {})
+
+    success = all([page['status'] == 'success' for page in fetch_status])
+    total_items = sum([page['document_count'] for page in fetch_status])
+    total_pages = fetch_status[-1]['page'] + 1
+    diff_items = total_items - collection['solr_count']
+    date = datetime.strptime(
+        collection['solr_last_updated'],
+        "%Y-%m-%dT%H:%M:%S.%f"
+    )
+
+    print(
+        f"{'Successfully fetched' if success else 'Error fetching'} "
+        f"collection {collection['collection_id']}"
+    )
+    print(
+        f"Fetched {total_items} items across {total_pages} pages "
+        f"at a rate of ~{total_items / total_pages} items per page"
+    )
+    print(
+        f"As of {datetime.strftime(date, '%B %d, %Y %H:%M:%S.%f')} "
+        f"Solr has {collection['solr_count']} items"
+    )
+    if diff_items != 0:
+        print(
+            f"Rikolti fetched {abs(diff_items)} "
+            f"{'more' if diff_items > 0 else 'fewer'} items."
+        )
+
+    return [
+        str(page['page']) for page in fetch_status if page['status']=='success'
+    ]
+
+
+@task()
+def get_collection_metadata_task(params=None):
+    if not params or not params.get('collection_id'):
+        raise ValueError("Collection ID not found in params")
+    collection_id = params.get('collection_id')
+
+    resp = requests.get(
+        "https://registry.cdlib.org/api/v1/"
+        f"rikolticollection/{collection_id}/?format=json"
+    )
+    resp.raise_for_status()
+
+    return resp.json()
+
+
+# max_active_tis_per_dag - setting on the task to restrict how many
+# instances can be running at the same time, *across all DAG runs*
+@task()
+def map_page_task(page: str, collection: dict):
+    collection_id = collection.get('id')
+    if not collection_id:
+        return False
+    mapped_page = map_page(collection_id, page, collection)
+    return mapped_page
+
+
+@task()
+def get_mapping_status_task(collection: dict, mapped_pages: list):
+    mapping_status = get_mapping_status(collection, mapped_pages)
+    return mapping_status

--- a/metadata_fetcher/lambda_function.py
+++ b/metadata_fetcher/lambda_function.py
@@ -28,33 +28,33 @@ def fetch_collection(payload, context):
 
     fetcher_class = import_fetcher(payload.get('harvest_type'))
 
-    fetch_report = {'page': payload.get('write_page', 0), 'document_count': 0}
+    fetch_status = {'page': payload.get('write_page', 0), 'document_count': 0}
     try:
         fetcher = fetcher_class(payload)
-        fetch_report['document_count'] = fetcher.fetch_page()
+        fetch_status['document_count'] = fetcher.fetch_page()
     except InvalidHarvestEndpoint as e:
         logger.error(e)
-        fetch_report.update({
+        fetch_status.update({
             'status': 'error',
             'body': json.dumps({
                 'error': repr(e),
                 'payload': payload
             })
         })
-        return [fetch_report]
+        return [fetch_status]
 
     next_page = fetcher.json()
-    fetch_report.update({
+    fetch_status.update({
         'status': 'success',
         'next_page': next_page
     })
 
-    fetch_report = [fetch_report]
+    fetch_status = [fetch_status]
 
     if not json.loads(next_page).get('finished'):
-        fetch_report.extend(fetch_collection(next_page, {}))
+        fetch_status.extend(fetch_collection(next_page, {}))
 
-    return fetch_report
+    return fetch_status
 
 
 if __name__ == "__main__":

--- a/metadata_mapper/lambda_shepherd.py
+++ b/metadata_mapper/lambda_shepherd.py
@@ -76,7 +76,7 @@ def get_vernacular_pages(collection_id):
     return page_list
 
 
-def get_mapping_summary(mapped_pages):
+def get_mapping_status(collection, mapped_pages):
     count = sum([page['num_records_mapped'] for page in mapped_pages])
     page_count = len(mapped_pages)
     collection_exceptions = [page.get('page_exceptions', {}) for page in mapped_pages]
@@ -87,6 +87,11 @@ def get_mapping_summary(mapped_pages):
             group_exceptions.setdefault(exception, []).extend(couch_ids)
 
     return {
+        'status': 'success',
+        'collection_id': collection.get('id'),
+        'pre_mapping': collection.get('rikolti__pre_mapping'),
+        'enrichments': collection.get('rikolti__enrichments'),
+        'missing_enrichments': check_for_missing_enrichments(collection),
         'count': count,
         'page_count': page_count,
         'group_exceptions': group_exceptions
@@ -121,7 +126,7 @@ def map_collection(collection_id, validate=False):
             )
             continue
 
-    collection_stats = get_mapping_summary(mapped_pages)
+    collection_stats = get_mapping_status(collection, mapped_pages)
 
     if validate:
         opts = validate if isinstance(validate, dict) else {}
@@ -130,16 +135,7 @@ def map_collection(collection_id, validate=False):
             **opts
             )
 
-    return {
-        'status': 'success',
-        'collection_id': collection_id,
-        'pre_mapping': collection.get('rikolti__pre_mapping'),
-        'enrichments': collection.get('rikolti__enrichments'),
-        'missing_enrichments': check_for_missing_enrichments(collection),
-        'records_mapped': collection_stats.get('count'),
-        'pages_mapped': collection_stats.get('page_count'),
-        'exceptions': collection_stats.get('group_exceptions')
-    }
+    return collection_stats
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Most notably, this PR creates a `harvest_dag.py` and moves all dag tasks definitions there. Keeping code local to the general case - running the full harvesting pipeline - was helpful in thinking about structuring the inputs and outputs as ideal to this general case. @bibliotechy I can move these back either temporarily (to make reviewing the changes made by this PR within each task a bit easier), or permanently if you think it makes more sense to functionally encapsulate these task definitions. 

This PR also
- standardizes on using `params` method to get dag run parameters (as opposed to `dag_run.conf` or `get_current_context()`)
- standardizes dags as taking a collection id while dag tasks should take a collection metadata resource from the registry API. 
- updates the fetcher task to print the fetcher task status, and return a list of successfully fetched page filenames, eliminating the need to then go get the vernacular pages as the first step of the mapping task in the full harvest pipeline (though this is still needed when running just the mapper_dag, and this may require some finessing when using an s3 data source)
- standardizing on usage of the words "status" to refer to conceptual task status (number of pages successfully fetched, mapping enrichment errors encountered, etc), rather than "summary" and "report"
