### PR TITLE
fix: factor out shared tasks

### DIFF
--- a/dags/fetcher_dag.py
+++ b/dags/fetcher_dag.py
@@ -3,8 +3,8 @@ from datetime import datetime
 from airflow.decorators import dag
 from airflow.models.param import Param
 
-from rikolti.dags.harvest_dag import get_collection_fetchdata_task
-from rikolti.dags.harvest_dag import fetch_collection_task
+from rikolti.dags.shared_tasks import get_collection_fetchdata_task
+from rikolti.dags.shared_tasks import fetch_collection_task
 
 @dag(
     dag_id="fetch_collection",

--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -1,97 +1,15 @@
-import requests
 from datetime import datetime
 
-from airflow.decorators import dag, task
+from airflow.decorators import dag
 from airflow.models.param import Param
 
-from rikolti.metadata_fetcher.lambda_function import fetch_collection
-from rikolti.metadata_mapper.lambda_function import map_page
-from rikolti.metadata_mapper.lambda_shepherd import get_mapping_status
 
+from rikolti.dags.shared_tasks import fetch_collection_task
+from rikolti.dags.shared_tasks import get_collection_fetchdata_task
+from rikolti.dags.shared_tasks import get_collection_metadata_task
+from rikolti.dags.shared_tasks  import map_page_task
+from rikolti.dags.shared_tasks  import get_mapping_status_task
 
-# TODO: remove the rikoltifetcher registry endpoint and restructure
-# the fetch_collection function to accept a rikolticollection resource.
-@task()
-def get_collection_fetchdata_task(params=None):
-    if not params or not params.get('collection_id'):
-        raise ValueError("Collection ID not found in params")
-    collection_id = params.get('collection_id')
-
-    resp = requests.get(
-        "https://registry.cdlib.org/api/v1/"
-        f"rikoltifetcher/{collection_id}/?format=json"
-    )
-    resp.raise_for_status()
-
-    return resp.json()
-
-
-@task()
-def fetch_collection_task(collection: dict):
-    fetch_status = fetch_collection(collection, {})
-
-    success = all([page['status'] == 'success' for page in fetch_status])
-    total_items = sum([page['document_count'] for page in fetch_status])
-    total_pages = fetch_status[-1]['page'] + 1
-    diff_items = total_items - collection['solr_count']
-    date = datetime.strptime(
-        collection['solr_last_updated'],
-        "%Y-%m-%dT%H:%M:%S.%f"
-    )
-
-    print(
-        f"{'Successfully fetched' if success else 'Error fetching'} "
-        f"collection {collection['collection_id']}"
-    )
-    print(
-        f"Fetched {total_items} items across {total_pages} pages "
-        f"at a rate of ~{total_items / total_pages} items per page"
-    )
-    print(
-        f"As of {datetime.strftime(date, '%B %d, %Y %H:%M:%S.%f')} "
-        f"Solr has {collection['solr_count']} items"
-    )
-    if diff_items != 0:
-        print(
-            f"Rikolti fetched {abs(diff_items)} "
-            f"{'more' if diff_items > 0 else 'fewer'} items."
-        )
-
-    return [
-        str(page['page']) for page in fetch_status if page['status']=='success'
-    ]
-
-
-@task()
-def get_collection_metadata_task(params=None):
-    if not params or not params.get('collection_id'):
-        raise ValueError("Collection ID not found in params")
-    collection_id = params.get('collection_id')
-
-    resp = requests.get(
-        "https://registry.cdlib.org/api/v1/"
-        f"rikolticollection/{collection_id}/?format=json"
-    )
-    resp.raise_for_status()
-
-    return resp.json()
-
-
-# max_active_tis_per_dag - setting on the task to restrict how many
-# instances can be running at the same time, *across all DAG runs*
-@task()
-def map_page_task(page: str, collection: dict):
-    collection_id = collection.get('id')
-    if not collection_id:
-        return False
-    mapped_page = map_page(collection_id, page, collection)
-    return mapped_page
-
-
-@task()
-def get_mapping_status_task(collection: dict, mapped_pages: list):
-    mapping_status = get_mapping_status(collection, mapped_pages)
-    return mapping_status
 
 
 @dag(

--- a/dags/mapper_dag.py
+++ b/dags/mapper_dag.py
@@ -2,9 +2,10 @@ from datetime import datetime
 
 from airflow.decorators import dag, task
 from airflow.models.param import Param
-from rikolti.dags.harvest_dag import get_collection_metadata_task
-from rikolti.dags.harvest_dag import map_page_task
-from rikolti.dags.harvest_dag import get_mapping_status_task
+
+from rikolti.dags.shared_tasks import get_collection_metadata_task
+from rikolti.dags.shared_tasks import map_page_task
+from rikolti.dags.shared_tasks import get_mapping_status_task
 from rikolti.metadata_mapper.lambda_shepherd import get_vernacular_pages
 
 

--- a/dags/shared_tasks.py
+++ b/dags/shared_tasks.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+
+import requests
+from airflow.decorators import task
+
+from rikolti.metadata_fetcher.lambda_function import fetch_collection
+from rikolti.metadata_mapper.lambda_function import map_page
+from rikolti.metadata_mapper.lambda_shepherd import get_mapping_status
+
+
+# TODO: remove the rikoltifetcher registry endpoint and restructure
+# the fetch_collection function to accept a rikolticollection resource.
+@task()
+def get_collection_fetchdata_task(params=None):
+    if not params or not params.get('collection_id'):
+        raise ValueError("Collection ID not found in params")
+    collection_id = params.get('collection_id')
+
+    resp = requests.get(
+        "https://registry.cdlib.org/api/v1/"
+        f"rikoltifetcher/{collection_id}/?format=json"
+    )
+    resp.raise_for_status()
+
+    return resp.json()
+
+
+@task()
+def fetch_collection_task(collection: dict):
+    fetch_status = fetch_collection(collection, {})
+
+    success = all([page['status'] == 'success' for page in fetch_status])
+    total_items = sum([page['document_count'] for page in fetch_status])
+    total_pages = fetch_status[-1]['page'] + 1
+    diff_items = total_items - collection['solr_count']
+    date = datetime.strptime(
+        collection['solr_last_updated'],
+        "%Y-%m-%dT%H:%M:%S.%f"
+    )
+
+    print(
+        f"{'Successfully fetched' if success else 'Error fetching'} "
+        f"collection {collection['collection_id']}"
+    )
+    print(
+        f"Fetched {total_items} items across {total_pages} pages "
+        f"at a rate of ~{total_items / total_pages} items per page"
+    )
+    print(
+        f"As of {datetime.strftime(date, '%B %d, %Y %H:%M:%S.%f')} "
+        f"Solr has {collection['solr_count']} items"
+    )
+    if diff_items != 0:
+        print(
+            f"Rikolti fetched {abs(diff_items)} "
+            f"{'more' if diff_items > 0 else 'fewer'} items."
+        )
+
+    return [
+        str(page['page']) for page in fetch_status if page['status']=='success'
+    ]
+
+
+@task()
+def get_collection_metadata_task(params=None):
+    if not params or not params.get('collection_id'):
+        raise ValueError("Collection ID not found in params")
+    collection_id = params.get('collection_id')
+
+    resp = requests.get(
+        "https://registry.cdlib.org/api/v1/"
+        f"rikolticollection/{collection_id}/?format=json"
+    )
+    resp.raise_for_status()
+
+    return resp.json()
+
+
+# max_active_tis_per_dag - setting on the task to restrict how many
+# instances can be running at the same time, *across all DAG runs*
+@task()
+def map_page_task(page: str, collection: dict):
+    collection_id = collection.get('id')
+    if not collection_id:
+        return False
+    mapped_page = map_page(collection_id, page, collection)
+    return mapped_page
+
+
+@task()
+def get_mapping_status_task(collection: dict, mapped_pages: list):
+    mapping_status = get_mapping_status(collection, mapped_pages)
+    return mapping_status


### PR DESCRIPTION
Factors out all of the reused tasks into `shared_tasks.py`.

It appears that any task that is going to be re-used in multiple dags across multiple files needs to be in a separate file that does not define any dags, otherwise importing that task will also trigger the import of the dag.