### PR TITLE
Content DAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ export CONTENT_DEST=file:///rikolti_content
 
 The folder located at `CONTENT_DATA_MOUNT` is mounted to `/rikolti_data` and the folder located at `CONTENT_MOUNT` is mounted to `/rikolti_content` on the content_harvester docker container.
 
-Run `docker build -t content_harvester content_harvester` to build the `content_harvester` container locally.
+Run `docker build -t content_harvester content_harvester` to build the `content_harvester` container locally. 
+
+You can specify a `content_harvester_image` and `content_harvester_version` through the Airflow UI > Admin > Variables. The default value for `content_harvester_image` is `content_harvester` and the default value for `content_harvester_version` is `latest`.
 
 Finally, run `./mwaa-local-env build-image` to build the docker image, and `./mwaa-local-env start` to start the mwaa local environment.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ On each merge to `main`, an `AWS CodeBuild` task will run, triggered by a webhoo
 
 AWS provides the [aws-mwaa-local-runner](https://github.com/aws/aws-mwaa-local-runner) repo, which provides a command line interface (CLI) utility that replicates an Amazon Managed Workflows for Apache Airflow (MWAA) environment locally via use of a Docker container. We have forked this repository and made some small changes to enable us to use local-runner while keeping our dags stored in this repository. (See this slack thread for more info: https://apache-airflow.slack.com/archives/CCRR5EBA7/p1690405849653759)
 
-To set up this dev environment, first clone the repo locally:
+To set up the airflow dev environment, clone the repo locally:
 
 ```
 git clone git@github.com:ucldc/aws-mwaa-local-runner.git
@@ -147,7 +147,14 @@ Then, copy `aws-mwaa-local-runner/docker/.env.example`:
 cp aws-mwaa-local-runner/docker/.env.example aws-mwaa-local-runner/docker/.env
 ```
 
-Set the following env vars to wherever the directories live on your machine, for example:
+If you have not already, you should also clone the rikolti repo locally. 
+> Note: The location of the Rikolti repo relative to the aws-mwaa-local-runner repo does not matter - we will configure some environment variables so the aws-mwaa-local-runner can find Rikolti. 
+
+```
+git clone git@github.com:ucldc/rikolti.git
+```
+
+Back in `aws-mwaa-local-runner/docker/.env`, set the following env vars to wherever you have cloned the rikolti repository, for example:
 
 ```
 DAGS_HOME="/Users/username/dev/rikolti"
@@ -162,7 +169,7 @@ These env vars are used in the `aws-mwaa-local-runner/docker/docker-compose-loca
 
 The docker socket will typically be at `/var/run/docker.sock`. On Mac OS Docker Desktop you can check that the socket is available and at this location by opening Docker Desktop's settings, looking under "Advanced", and checking the "Allow the Docker socket to be used" setting. 
 
-Then, create the `startup.sh` file by running `cp env.example startup.sh`. Update the startup.sh file with Nuxeo, Flickr, and Solr keys as available, and make sure that the following environment variables are set:
+Next, back in the Rikolti repository, create the `startup.sh` file by running `cp env.example startup.sh`. Update the startup.sh file with Nuxeo, Flickr, and Solr keys as available, and make sure that the following environment variables are set:
 
 ```
 export FETCHER_DATA_DEST=file:///usr/local/airflow/rikolti_data

--- a/content_harvester/Dockerfile
+++ b/content_harvester/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -qq && apt-get install -y libtiff-tools ffmpeg
 # so we need to comment out this line in the the policy
 RUN sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<!--<policy domain="coder" rights="none" pattern="PDF" \/>-->/' /etc/ImageMagick-6/policy.xml
 
-WORKDIR /content_harvester
+WORKDIR /
 
 COPY requirements.txt ./
 
@@ -15,4 +15,5 @@ RUN pip install --upgrade pip && pip install -r requirements.txt
 
 COPY ./ /content_harvester
 
-ENTRYPOINT [ "python", "by_registry_endpoint.py" ]
+# ENTRYPOINT [ "python", "-m", "content_harvester.by_registry_endpoint" ]
+ENTRYPOINT ["python3", "-m", "content_harvester.by_collection"]

--- a/content_harvester/Dockerfile
+++ b/content_harvester/Dockerfile
@@ -18,4 +18,5 @@ COPY ./ /content_harvester
 RUN chmod +x /content_harvester/by_collection.py
 
 # ENTRYPOINT [ "python", "-m", "content_harvester.by_registry_endpoint" ]
-ENTRYPOINT ["python3", "-m", "content_harvester.by_collection"]
+# ENTRYPOINT ["python3", "-m", "content_harvester.by_collection"]
+ENTRYPOINT ["python3", "-m", "content_harvester.by_page"]

--- a/content_harvester/Dockerfile
+++ b/content_harvester/Dockerfile
@@ -15,5 +15,7 @@ RUN pip install --upgrade pip && pip install -r requirements.txt
 
 COPY ./ /content_harvester
 
+RUN chmod +x /content_harvester/by_collection.py
+
 # ENTRYPOINT [ "python", "-m", "content_harvester.by_registry_endpoint" ]
 ENTRYPOINT ["python3", "-m", "content_harvester.by_collection"]

--- a/content_harvester/by_collection.py
+++ b/content_harvester/by_collection.py
@@ -9,7 +9,7 @@ from .by_page import harvest_page_content
 
 def get_mapped_pages(collection_id):
     page_list = []
-    if settings.METADATA_SRC == 'local':
+    if settings.DATA_SRC['STORE'] == 'file':
         mapped_path = settings.local_path('mapped_metadata', collection_id)
         try:
             page_list = [f for f in os.listdir(mapped_path)
@@ -25,7 +25,7 @@ def get_mapped_pages(collection_id):
             region_name=settings.AWS_REGION
         )
         response = s3_client.list_objects_v2(
-            Bucket=settings.S3_BUCKET,
+            Bucket=settings.DATA_SRC["BUCKET"],
             Prefix=f'mapped_metadata/{collection_id}/'
         )
         page_list = [obj['Key'].split('/')[-1] for obj in response['Contents']]

--- a/content_harvester/by_page.py
+++ b/content_harvester/by_page.py
@@ -359,6 +359,16 @@ def harvest_page_content(collection_id, page_filename, **kwargs):
             record_with_content = harvester.harvest(record)
             write_mapped_record(
                 collection_id, record_with_content, harvester.s3)
+            if not record_with_content.get('thumbnail'):
+                warn_level = "ERROR"
+                if 'sound' in record.get('type', []):
+                    warn_level = "WARNING"
+                print(
+                    f"[{collection_id}, {page_filename}]: "
+                    f"{record.get('calisphere-id')}: {warn_level} - "
+                    f"NO THUMBNAIL: {record.get('type')}"
+                )
+
         except Exception as e:
             print(
                 f"[{collection_id}, {page_filename}, "
@@ -367,16 +377,6 @@ def harvest_page_content(collection_id, page_filename, **kwargs):
             print(f"Exiting after harvesting {i} of {len(records)} items "
                   f"in page {page_filename} of collection {collection_id}")
             raise e
-
-        if not record_with_content.get('thumbnail'):
-            warn_level = "ERROR"
-            if 'sound' in record.get('type', []):
-                warn_level = "WARNING"
-            print(
-                f"[{collection_id}, {page_filename}]: "
-                f"{record.get('calisphere-id')}: {warn_level} - "
-                f"NO THUMBNAIL: {record.get('type')}"
-            )
 
     # reporting aggregate stats
     media_mimetypes = [

--- a/content_harvester/by_page.py
+++ b/content_harvester/by_page.py
@@ -409,9 +409,11 @@ def harvest_page_content(collection_id, page_filename, **kwargs):
             f"Mimetypes: {Counter(media_mimetypes)}"
         )
 
-    thumb_source = [r for r in records if r.get('thumbnail_source', r.get('is_shown_by'))]
+    thumb_source = [
+        r for r in records if r.get('thumbnail_source', r.get('is_shown_by'))]
     thumb_harvested = [r for r in records if r.get('thumbnail')]
-    thumb_src_mimetypes = [r.get('thumbnail_source', {}).get('mimetype') for r in records]
+    thumb_src_mimetypes = [
+        r.get('thumbnail_source', {}).get('mimetype') for r in records]
     thumb_mimetypes = [r.get('thumbnail', {}).get('mimetype') for r in records]
     print(
         f"[{collection_id}, {page_filename}]: Harvested "

--- a/content_harvester/by_page.py
+++ b/content_harvester/by_page.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 from collections import Counter
 
 import boto3
@@ -12,6 +13,10 @@ from . import settings
 
 
 class DownloadError(Exception):
+    pass
+
+
+class UnsupportedMimetype(Exception):
     pass
 
 
@@ -34,13 +39,24 @@ def get_mapped_records(collection_id, page_filename, s3_client) -> list:
 def write_mapped_record(collection_id, record, s3_client):
     if settings.DATA_DEST["STORE"] == 'file':
         local_path = settings.local_path('mapped_with_content', collection_id)
-        page_path = os.path.join(local_path, str(record.get('calisphere-id')))
+        if not os.path.exists(local_path):
+            os.makedirs(local_path)
+        
+        # some ids have slashes
+        page_path = os.path.join(
+            local_path,
+            record.get('calisphere-id').replace(os.sep, '_')
+        )
+        
         page = open(page_path, "w")
         page.write(json.dumps(record))
     else:
         upload_status = s3_client.put_object(
             Bucket=settings.DATA_DEST["BUCKET"],
-            Key=f"mapped_with_content/{collection_id}/{record.get('calisphere-id')}",
+            Key=(
+                f"mapped_with_content/{collection_id}/"
+                f"{record.get('calisphere-id')}"
+            ),
             Body=json.dumps(record)
         )
         print(f"Upload status: {upload_status}")
@@ -74,39 +90,120 @@ def get_child_records(collection_id, parent_id, s3_client) -> list:
     return mapped_child_records
 
 
-class UnsupportedMimetype(Exception):
-    pass
-
-
-def check_mimetype(mimetype):
-    ''' do a basic pre-check on the object to see if we think it's
-    something know how to deal with '''
-    valid_types = [
-        'image/jpeg', 'image/gif', 'image/tiff', 'image/png',
-        'image/jp2', 'image/jpx', 'image/jpm'
-    ]
-
-    # see if we recognize this mime type
-    if mimetype in valid_types:
-        print(
-            f"Mime-type '{mimetype}' was pre-checked and recognized as "
-            "something we can try to convert."
+class Content(object):
+    def __init__(self, content_src):
+        self.missing = True if not content_src else False
+        self.src_url = content_src.get('url')
+        self.src_filename = content_src.get(
+            'filename',
+            list(
+                filter(
+                    lambda x: bool(x), content_src.get('url', '').split('/')
+                )
+            )[-1]
         )
-    elif mimetype in ['application/pdf']:
-        raise UnsupportedMimetype(
-            f"Mime-type '{mimetype}' was pre-checked and recognized as "
-            "something we don't want to convert."
-        )
-    else:
-        raise UnsupportedMimetype(
-            f"Mime-type '{mimetype}' was unrecognized. We don't know how to "
-            "deal with this"
+        self.src_mime_type = content_src.get('mimetype')
+        self.tmp_filepath = os.path.join('/tmp', self.src_filename)
+        self.derivative_filepath = None
+        self.s3_filepath = None
+
+    def downloaded(self):
+        return os.path.exists(self.tmp_filepath)
+
+    def processed(self):
+        return (
+            self.derivative_filepath and 
+            os.path.exists(self.derivative_filepath)
         )
 
+    def set_s3_filepath(self, s3_filepath):
+        self.s3_filepath = s3_filepath
 
-def check_thumb_mimetype(mimetype):
-    if mimetype not in ['image/jpeg', 'application/pdf', 'video/mp4']:
-        raise UnsupportedMimetype(f"thumbnail: {mimetype}")
+    def __bool__(self):
+        return not self.missing
+
+    def __del__(self):
+        if self.downloaded() and self.tmp_filepath != self.s3_filepath:
+            os.remove(self.tmp_filepath)
+        if self.processed() and self.derivative_filepath != self.s3_filepath:
+            os.remove(self.derivative_filepath)
+
+
+class Media(Content):
+    def __init__(self, content_src):
+        super().__init__(content_src)
+        self.src_nuxeo_type = content_src.get('nuxeo_type')
+        if self.src_nuxeo_type == 'SampleCustomPicture':
+            self.dest_mime_type = 'image/jp2'
+            self.dest_prefix = "jp2"
+        else:
+            self.dest_mime_type = self.src_mime_type
+            self.dest_prefix = "media"
+
+    def create_derivatives(self):
+        self.derivative_filepath = self.tmp_filepath
+        if self.src_nuxeo_type == 'SampleCustomPicture':
+            try:
+                self.check_mimetype(self.src_mime_type)
+                self.derivative_filepath = derivatives.make_jp2(
+                    self.tmp_filepath)
+            except UnsupportedMimetype as e:
+                print(
+                    "ERROR: nuxeo type is SampleCustomPicture, "
+                    "but mimetype is not supported"
+                )
+                raise(e)
+
+    def check_mimetype(self, mimetype):
+        ''' do a basic pre-check on the object to see if we think it's
+        something know how to deal with '''
+        valid_types = [
+            'image/jpeg', 'image/gif', 'image/tiff', 'image/png',
+            'image/jp2', 'image/jpx', 'image/jpm'
+        ]
+
+        # see if we recognize this mime type
+        if mimetype in valid_types:
+            print(
+                f"Mime-type '{mimetype}' was pre-checked and recognized as "
+                "something we can try to convert."
+            )
+        elif mimetype in ['application/pdf']:
+            raise UnsupportedMimetype(
+                f"Mime-type '{mimetype}' was pre-checked and recognized as "
+                "something we don't want to convert."
+            )
+        else:
+            raise UnsupportedMimetype(
+                f"Mime-type '{mimetype}' was unrecognized. We don't know how "
+                "to deal with this"
+            )
+
+
+class Thumbnail(Content):
+    def __init__(self, content_src):
+        super().__init__(content_src)
+        self.src_mime_type = content_src.get('mimetype', 'image/jpeg')
+        self.dest_mime_type = 'image/jpeg' # do we need this? 
+        self.dest_prefix = "thumbnails"
+
+    def create_derivatives(self):
+        # TODO: the image harvest md5 thing
+        self.derivative_filepath = None
+        if self.src_mime_type == 'image/jpeg':
+            self.derivative_filepath = self.tmp_filepath
+        elif self.src_mime_type == 'application/pdf':
+            self.derivative_filepath = derivatives.pdf_to_thumb(
+                self.tmp_filepath)
+        elif self.src_mime_type == 'video/mp4':
+            self.derivative_filepath = derivatives.video_to_thumb(
+                self.tmp_filepath)
+        else:
+            raise UnsupportedMimetype(f"thumbnail: {self.src_mime_type}")
+
+    def check_mimetype(self, mimetype):
+        if mimetype not in ['image/jpeg', 'application/pdf', 'video/mp4']:
+            raise UnsupportedMimetype(f"thumbnail: {mimetype}")
 
 
 class ContentHarvester(object):
@@ -127,78 +224,10 @@ class ContentHarvester(object):
         self.harvest_context = context
 
         if settings.CONTENT_DEST["STORE"] == 's3':
-            self.s3 = boto3.client(
-                's3',
-                aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-                aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-                aws_session_token=settings.AWS_SESSION_TOKEN,
-                region_name=settings.AWS_REGION
-            )
+            self.s3 = boto3.client('s3')
         else:
             self.s3 = None
 
-    # returns media_dest = {media_filepath, mimetype}
-    def harvest_media(self, media_src, media_src_file) -> dict:
-        if not media_src_file:
-            return None
-
-        media_filepath = None
-        if media_src.get('nuxeo_type') == 'SampleCustomPicture':
-            try:
-                check_mimetype(media_src.get('mimetype'))
-                media_filepath = derivatives.make_jp2(media_src_file)
-            except UnsupportedMimetype as e:
-                print(e)
-                media_filepath = media_src_file
-
-            media_dest = {'mimetype': 'image/jp2'}
-            if settings.CONTENT_DEST["STORE"] == 'file':
-                media_dest['media_filepath'] = media_filepath
-            else:
-                media_dest['media_filepath'] = self.upload_to_s3(
-                    'jp2', media_filepath)
-        else:
-            media_filepath = media_src_file
-            media_dest = {'mimetype': media_src.get('mimetype')}
-            if settings.CONTENT_DEST["STORE"] == 'file':
-                media_dest['media_filepath'] = media_filepath
-            else:
-                media_dest['media_filepath'] = self.upload_to_s3(
-                    'media', media_filepath)
-
-        return media_dest
-
-    # returns thumbnail_dest = {thumbnail_filepath, mimetype}
-    def harvest_thumbnail(self, thumbnail_src, thumbnail_src_file) -> dict:
-        # set default mimetype to 'image/jpeg' in cases where no mimetype is 
-        # specified (aka, all non-nuxeo cases)
-        if not thumbnail_src_file:
-            return None
-
-        thumb_mimetype = thumbnail_src.get('mimetype', 'image/jpeg')
-
-        thumbnail_filepath = None
-        if thumb_mimetype == 'image/jpeg':
-            thumbnail_filepath = thumbnail_src_file
-        elif thumb_mimetype == 'application/pdf':
-            thumbnail_filepath = derivatives.pdf_to_thumb(
-                thumbnail_src_file)
-        elif thumb_mimetype == 'video/mp4':
-            thumbnail_filepath = derivatives.video_to_thumb(
-                thumbnail_src_file)
-        else:
-            raise UnsupportedMimetype(f"thumbnail: {thumb_mimetype}")
-
-        # TODO: the image harvest md5 thing + do we need thumbnail destination
-        # mimetype if it's always image/jpeg? (is it always image/jpeg?)
-        thumbnail_dest = {'mimetype': 'image/jpeg'}
-
-        if settings.CONTENT_DEST["STORE"] == 'file':
-            thumbnail_dest['thumbnail_filepath'] = thumbnail_filepath
-        else:
-            thumbnail_dest['thumbnail_filepath'] = self.upload_to_s3(
-                'thumbnails', thumbnail_filepath)
-        return thumbnail_dest
 
     # returns content = {thumbnail, media, children} where children
     # is an array of the self-same content dictionary
@@ -207,91 +236,58 @@ class ContentHarvester(object):
         collection_id = self.harvest_context.get('collection_id')
         page_filename = self.harvest_context.get('page_filename')
 
-        # Harvest Media File for Record
-        media_src = record.get('media_source')
-        media_src_file = self._download_src(media_src)
-        if media_src_file:
-            print(
-                f"[{collection_id}, {page_filename}, {calisphere_id}]: "
-                f"Media Source: {media_src}, Temp File: {media_src_file}, "
-                f"fsize: {os.path.getsize(media_src_file)}"
-            )
-        media_dest = self.harvest_media(media_src, media_src_file)
-        print(
-            f"[{collection_id}, {page_filename}, {calisphere_id}] "
-            f"Media Path: {media_dest}"
-        )
-
-        # Harvest Thumbnail File for Record
-        thumbnail_src = record.get('thumbnail_source')
-
-        # this makes it so we don't have to re-write isShownBy mappings for
-        # non-nuxeo sources
+        # maintain backwards compatibility to 'is_shown_by' field
+        thumbnail_src = record.get(
+            'thumbnail_source', record.get('is_shown_by'))
         if isinstance(thumbnail_src, str):
-            thumbnail_src = {'url': thumbnail_src}
+            record['thumbnail_source'] = {'url': thumbnail_src}
 
-        thumbnail_src_file = self._download_src(thumbnail_src)
-        if thumbnail_src_file:
+        # get media first, sometimes media is used for thumbnail
+        content_types = [(Media, 'media'), (Thumbnail, 'thumbnail')]
+        for content_cls, field in content_types:
+            content = record.get(f"{field}_source")
+            if not content:
+                continue
+
+            content = content_cls(content)            
+            if not content.downloaded():
+                self._download(content.src_url, content.tmp_filepath)
+            if not content.processed():
+                content.create_derivatives()
+            content_s3_filepath = self._upload(
+                content.dest_prefix, content.derivative_filepath)
+            content.set_s3_filepath(content_s3_filepath)
+
             print(
-                f"[{collection_id}, {page_filename}, {calisphere_id}]: "
-                f"Thumb Source: {thumbnail_src}, Temp File: "
-                f"{thumbnail_src_file}, fsize: "
-                f"{os.path.getsize(thumbnail_src_file)}"
+                f"[{collection_id}, {page_filename}, {calisphere_id}] "
+                f"{type(content).__name__} Path: {content.s3_filepath}"
             )
-        thumbnail_dest = self.harvest_thumbnail(
-            thumbnail_src, thumbnail_src_file)
-        print(
-            f"[{collection_id}, {page_filename}, {calisphere_id}] "
-            f"Thumbnail Path: {thumbnail_dest}"
-        )
-
-        if media_src_file:
-            os.remove(media_src_file)
-        if thumbnail_src_file:
-            os.remove(thumbnail_src_file)
+            
+            record[field] = {
+                'mimetype': content.dest_mime_type,
+                'path': content.s3_filepath
+            }
 
         # Recurse through the record's children (if any)
-        child_records = get_child_records(collection_id, calisphere_id, self.s3)
+        child_records = get_child_records(
+            collection_id, calisphere_id, self.s3)
+        if child_records:
+            print(
+                f"[{collection_id}, {page_filename}, {calisphere_id}]: "
+                f"{len(child_records)} children found."
+            )
+            record['children'] = [self.harvest(c) for c in child_records]
 
-        print(
-            f"[{collection_id}, {page_filename}, {calisphere_id}]: "
-            f"{len(child_records)} children found."
-        )
-
-        children_media = []
-        for child in child_records:
-            children_media.append(self.harvest(child))
-
-        record['thumbnail'] = thumbnail_dest
-        if media_dest:
-            record['media'] = media_dest
-        if children_media:
-            record['children'] = children_media
         return record
 
-    def _download_src(self, content_src) -> str:
+    def _download(self, url, destination_file):
         '''
             download source file to local disk
         '''
-        if not content_src:
-            return None
-
-        src_url = content_src.get('url')
-        # filename defaults to last part of the url (filter clause handles urls
-        # with a trailing slash where the [-1] last item is an empty string)
-        filename = content_src.get(
-            'filename',
-            list(filter(lambda x: bool(x), src_url.split('/')))[-1]
-        )
-
-        tmp_file_path = os.path.join('/tmp', filename)
-        if os.path.exists(tmp_file_path):
-            return tmp_file_path
-
         # Weird how we have to use username/pass to hit this endpoint
         # but we have to use auth token to hit API endpoint
         request = {
-            "url": src_url,
+            "url": url,
             "stream": True,
             "timeout": (12.05, (60 * 10) + 0.05)  # connect, read
         }
@@ -306,20 +302,34 @@ class ContentHarvester(object):
                 f"ERROR: failed to download source file: {err}"
             )
 
-        with open(tmp_file_path, 'wb') as f:
+        with open(destination_file, 'wb') as f:
             for block in response.iter_content(1024):
                 f.write(block)
 
-        return tmp_file_path
 
-    def upload_to_s3(self, s3_prefix, filepath) -> str:
+    def _upload(self, dest_prefix, filepath) -> str:
         '''
-            upload file to s3
+            upload file to CONTENT_DEST
         '''
-        s3_key = f"{s3_prefix}/{os.path.basename(filepath)}"
-        s3_url = f"{settings.CONTENT_DEST['PATH']}/{s3_key}"
-        self.s3.upload_file(filepath, settings.CONTENT_DEST["BUCKET"], s3_key)
-        return s3_url
+        filename = os.path.basename(filepath)
+        dest_path = None
+
+        if settings.CONTENT_DEST["STORE"] == 'file':
+            dest_path = os.path.join(
+                settings.CONTENT_DEST["PATH"], dest_prefix)
+            if not os.path.exists(dest_path):
+                os.makedirs(dest_path)
+            dest_path = os.path.join(dest_path, filename)
+            shutil.copyfile(filepath, dest_path)
+
+        if settings.CONTENT_DEST["STORE"] == 's3':
+            dest_path = (
+                f"{settings.CONTENT_DEST['PATH']}/{dest_prefix}/{filename}")
+            self.s3.upload_file(
+                filepath, settings.CONTENT_DEST["BUCKET"], dest_path)
+
+        return dest_path
+
 
 # {"collection_id": 26098, "rikolti_mapper_type": "nuxeo.nuxeo", "page_filename": "r-0"}
 def harvest_page_content(collection_id, page_filename, **kwargs):
@@ -347,11 +357,15 @@ def harvest_page_content(collection_id, page_filename, **kwargs):
         # spit out progress so far if an error has been encountered
         try:
             record_with_content = harvester.harvest(record)
-            write_mapped_record(collection_id, record_with_content, harvester.s3)
+            write_mapped_record(
+                collection_id, record_with_content, harvester.s3)
         except Exception as e:
             print(
-                f"ERROR: {e}\n{collection_id}, {page_filename}, {i}, {kwargs}"
+                f"[{collection_id}, {page_filename}, "
+                f"{record.get('calisphere-id')}]: ERROR: {e}"
             )
+            print(f"Exiting after harvesting {i} of {len(records)} items "
+                  f"in page {page_filename} of collection {collection_id}")
             raise e
 
         if not record_with_content.get('thumbnail'):
@@ -372,7 +386,9 @@ def harvest_page_content(collection_id, page_filename, **kwargs):
     media_source_mimetype = [
         record.get('media_source', {}).get('mimetype') for record in records]
     thumb_source_mimetype = [
-        record.get('thumbnail_source', {}).get('mimetype') for record in records]
+        record.get('thumbnail_source', {}).get('mimetype')
+        for record in records
+    ]
     child_contents = [len(record.get('children', [])) for record in records]
 
     return {

--- a/content_harvester/by_page.py
+++ b/content_harvester/by_page.py
@@ -453,4 +453,4 @@ if __name__ == "__main__":
     }
     if args.nuxeo:
         arguments['rikolti_mapper_type'] = 'nuxeo.nuxeo'
-    print(harvest_page_content(arguments))
+    print(harvest_page_content(**arguments))

--- a/content_harvester/docker-compose.yml
+++ b/content_harvester/docker-compose.yml
@@ -4,10 +4,19 @@ services:
       context: ./
       dockerfile: Dockerfile
     image: content_harvester
-    # command: tail -f /dev/null
-    working_dir: /content_harvester
+    # default entrypoint is python -m content_harvester.by_collection
+    # override with tail -f /dev/null to keep container running for development
+    entrypoint: tail -f /dev/null
+    # optionally, remove entrypoint override and uncomment command definition
+    # below to run a specific collection by id - 3433 in this example
+    # command: ["3433"]
+    working_dir: /
     volumes: 
-      - ../rikolti_bucket:/rikolti_bucket
+      - ../rikolti_data:/rikolti_data
+      - ../rikolti_content:/rikolti_content
       - ./:/content_harvester
-    env_file:
-      - ./env.local
+    environment:
+      - CONTENT_DATA_SRC=file:///rikolti_data
+      - CONTENT_DATA_DEST=file:///rikolti_data
+      - CONTENT_DEST=file:///rikolti_content
+      - NUXEO=${NUXEO}

--- a/content_harvester/docker-compose.yml
+++ b/content_harvester/docker-compose.yml
@@ -4,11 +4,12 @@ services:
       context: ./
       dockerfile: Dockerfile
     image: content_harvester
-    # default entrypoint is python -m content_harvester.by_collection
+    # default entrypoint is python -m content_harvester.by_page
     # override with tail -f /dev/null to keep container running for development
     entrypoint: tail -f /dev/null
-    # optionally, remove entrypoint override and uncomment command definition
+    # optionally, swap entrypoint override and uncomment command definition
     # below to run a specific collection by id - 3433 in this example
+    # entrypoint: python3 -m content_harvester.by_collection
     # command: ["3433"]
     working_dir: /
     volumes: 

--- a/content_harvester/settings.py
+++ b/content_harvester/settings.py
@@ -1,16 +1,31 @@
 import os
 
+from urllib.parse import urlparse
+
 from dotenv import load_dotenv
 
 load_dotenv()
 
-METADATA_SRC = 'local'
-METADATA_DEST = 's3'
-CONTENT_DEST = 's3'
+DATA_SRC_URL = os.environ.get('CONTENT_DATA_SRC', 'file:///tmp')
+DATA_SRC = {
+    "STORE": urlparse(DATA_SRC_URL).scheme,
+    "BUCKET": urlparse(DATA_SRC_URL).netloc,
+    "PATH": urlparse(DATA_SRC_URL).path
+}
 
-S3_BUCKET = os.environ.get('S3_BUCKET', False)
-S3_CONTENT_BUCKET = os.environ.get('S3_CONTENT_BUCKET', False)
-S3_BASE_URL = os.environ.get('S3_BASE_URL', False)
+DATA_DEST_URL = os.environ.get('CONTENT_DATA_DEST', 'file:///tmp')
+DATA_DEST = {
+    "STORE": urlparse(DATA_DEST_URL).scheme,
+    "BUCKET": urlparse(DATA_DEST_URL).netloc,
+    "PATH": urlparse(DATA_DEST_URL).path
+}
+
+CONTENT_DEST_URL = os.environ.get("CONTENT_DEST", 'file:///tmp')
+CONTENT_DEST = {
+    "STORE": urlparse(CONTENT_DEST_URL).scheme,
+    "BUCKET": urlparse(CONTENT_DEST_URL).netloc,
+    "PATH": urlparse(CONTENT_DEST_URL).path
+}
 
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', False)
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', False)
@@ -28,10 +43,8 @@ CONTENT_PROCESSES = {
 }
 
 def local_path(folder, collection_id):
-    parent_dir = os.sep.join(os.getcwd().split(os.sep)[:-1])
     local_path = os.sep.join([
-        parent_dir,
-        'rikolti_bucket',
+        DATA_SRC["PATH"],
         folder,
         str(collection_id),
     ])

--- a/content_harvester/tests.py
+++ b/content_harvester/tests.py
@@ -8,8 +8,7 @@ from .by_registry_endpoint import harvest_endpoint
 from .sample_data.nuxeo_harvests import nuxeo_complex_object_harvests
 
 def main():
-    mapped_path = settings.local_path(
-        'mapped_metadata', 0)[:-1]
+    mapped_path = settings.local_path('mapped_metadata', 0)[:-1]
     urls = [
         f"https://registry.cdlib.org/api/v1/rikoltimapper/{f}/?format=json"
         for f in os.listdir(mapped_path)

--- a/dags/content_dag.py
+++ b/dags/content_dag.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from docker.types import Mount
+from airflow.decorators import dag
+from airflow.models.param import Param
+
+from airflow.providers.docker.operators.docker import DockerOperator
+
+@dag(
+    dag_id="content_harvest",
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    params={'collection_id': Param(3433, description="Collection ID to harvet_content")},
+    tags=["rikolti"],
+)
+def content_harvest():
+    
+    content_harvester_task = DockerOperator(
+        task_id="content_harvester", 
+        image="content_harvester:latest",
+        container_name="content_harvest_dag_task",
+        command="{{ params.collection_id }}",
+        network_mode="bridge",
+        auto_remove='force',
+        mount_tmp_dir=False,
+        mounts=[
+            Mount(
+                source="/Users/awieliczka/Projects/rikolti_data",
+                target="/rikolti_data",
+                type="bind",
+            )
+        ]
+    )
+
+    content_harvester_task
+
+content_harvest()

--- a/dags/content_dag.py
+++ b/dags/content_dag.py
@@ -12,7 +12,7 @@ from airflow.providers.docker.operators.docker import DockerOperator
     schedule=None,
     start_date=datetime(2023, 1, 1),
     catchup=False,
-    params={'collection_id': Param(3433, description="Collection ID to harvet_content")},
+    params={'collection_id': Param(27425, description="Collection ID to harvet_content")},
     tags=["rikolti"],
 )
 def content_harvest():

--- a/dags/content_dag.py
+++ b/dags/content_dag.py
@@ -36,6 +36,25 @@ def content_harvest():
         task_id="content_harvester",
         image="content_harvester:latest",
         container_name="content_harvest_dag_task",
+        command=["{{ params.collection_id }}", "0"],
+        network_mode="bridge",
+        auto_remove='force',
+        mount_tmp_dir=False,
+        mounts=mounts,
+        environment={
+            "CONTENT_DATA_SRC": os.environ.get("CONTENT_DATA_SRC"),
+            "CONTENT_DATA_DEST": os.environ.get("CONTENT_DATA_DEST"),
+            "CONTENT_DEST": os.environ.get("CONTENT_DEST"),
+            "NUXEO": os.environ.get("NUXEO"),
+        }
+    )
+    content_harvester_task
+
+    collection_content_harvester_task = DockerOperator(
+        task_id="collection_content_harvester",
+        image="content_harvester:latest",
+        container_name="collection_content_harvest_dag_task",
+        entrypoint="python3 -m content_harvester.by_collection",
         command=["{{ params.collection_id }}"],
         network_mode="bridge",
         auto_remove='force',
@@ -49,6 +68,6 @@ def content_harvest():
         }
     )
 
-    content_harvester_task
+    collection_content_harvester_task
 
 content_harvest()

--- a/dags/content_dag.py
+++ b/dags/content_dag.py
@@ -1,5 +1,3 @@
-import os
-
 from datetime import datetime
 from airflow.decorators import dag
 from airflow.models.param import Param
@@ -11,7 +9,10 @@ from rikolti.dags.shared_tasks import ContentHarvestDockerOperator
     schedule=None,
     start_date=datetime(2023, 1, 1),
     catchup=False,
-    params={'collection_id': Param(27425, description="Collection ID to harvet_content")},
+    params={
+        'collection_id': 
+        Param(27425, description="Collection ID to harvet_content")
+    },
     tags=["rikolti"],
 )
 def content_harvest():

--- a/dags/content_dag.py
+++ b/dags/content_dag.py
@@ -1,11 +1,10 @@
 import os
 
 from datetime import datetime
-from docker.types import Mount
 from airflow.decorators import dag
 from airflow.models.param import Param
 
-from airflow.providers.docker.operators.docker import DockerOperator
+from rikolti.dags.shared_tasks import ContentHarvestDockerOperator
 
 @dag(
     dag_id="content_harvest",
@@ -16,58 +15,20 @@ from airflow.providers.docker.operators.docker import DockerOperator
     tags=["rikolti"],
 )
 def content_harvest():
-    mounts = []
-    if os.environ.get("CONTENT_DATA_MOUNT"):
-        mounts.append(Mount(
-            source=os.environ.get("CONTENT_DATA_MOUNT"),
-            target="/rikolti_data",
-            type="bind",
-        ))
-    if os.environ.get("CONTENT_MOUNT"):
-        mounts.append(Mount(
-            source=os.environ.get("CONTENT_MOUNT"),
-            target="/rikolti_content",
-            type="bind",
-        ))
-    if not mounts:
-        mounts=None
-
-    content_harvester_task = DockerOperator(
-        task_id="content_harvester",
-        image="content_harvester:latest",
-        container_name="content_harvest_dag_task",
-        command=["{{ params.collection_id }}", "0"],
-        network_mode="bridge",
-        auto_remove='force',
-        mount_tmp_dir=False,
-        mounts=mounts,
-        environment={
-            "CONTENT_DATA_SRC": os.environ.get("CONTENT_DATA_SRC"),
-            "CONTENT_DATA_DEST": os.environ.get("CONTENT_DATA_DEST"),
-            "CONTENT_DEST": os.environ.get("CONTENT_DEST"),
-            "NUXEO": os.environ.get("NUXEO"),
-        }
+    content_harvester_task = ContentHarvestDockerOperator(
+        task_id="page_content_harvester",
+        collection_id="{{ params.collection_id }}",
+        page=0,
     )
     content_harvester_task
 
-    collection_content_harvester_task = DockerOperator(
+    collection_content_harvester_task = ContentHarvestDockerOperator(
         task_id="collection_content_harvester",
-        image="content_harvester:latest",
-        container_name="collection_content_harvest_dag_task",
         entrypoint="python3 -m content_harvester.by_collection",
         command=["{{ params.collection_id }}"],
-        network_mode="bridge",
-        auto_remove='force',
-        mount_tmp_dir=False,
-        mounts=mounts,
-        environment={
-            "CONTENT_DATA_SRC": os.environ.get("CONTENT_DATA_SRC"),
-            "CONTENT_DATA_DEST": os.environ.get("CONTENT_DATA_DEST"),
-            "CONTENT_DEST": os.environ.get("CONTENT_DEST"),
-            "NUXEO": os.environ.get("NUXEO"),
-        }
+        collection_id="{{ params.collection_id }}",
+        page="all",
     )
-
     collection_content_harvester_task
 
 content_harvest()

--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from airflow.decorators import dag
+from airflow.decorators import dag, task
 from airflow.models.param import Param
 
 
@@ -9,8 +9,11 @@ from rikolti.dags.shared_tasks import get_collection_fetchdata_task
 from rikolti.dags.shared_tasks import get_collection_metadata_task
 from rikolti.dags.shared_tasks  import map_page_task
 from rikolti.dags.shared_tasks  import get_mapping_status_task
+from rikolti.dags.shared_tasks import ContentHarvestDockerOperator
 
-
+@task()
+def get_mapped_page_filenames_task(mapped_pages):
+    return [mapped['page_filename'] for mapped in mapped_pages]
 
 @dag(
     dag_id="harvest_collection",
@@ -33,6 +36,19 @@ def harvest():
             .expand(page=fetched_pages)
     )
     get_mapping_status_task(collection, mapped_pages)
+    mapped_page_filenames = get_mapped_page_filenames_task(mapped_pages)
+
+    content_harvest_task = (
+        ContentHarvestDockerOperator
+            .partial(
+                task_id="content_harvest", 
+                collection_id="{{ params.collection_id }}",
+            )
+            .expand(
+                page=mapped_page_filenames
+            )
+    )
+    content_harvest_task
     
 
 harvest()

--- a/dags/requirements.txt
+++ b/dags/requirements.txt
@@ -2,3 +2,4 @@
 requests
 sickle
 python-dotenv
+apache-airflow-providers-docker

--- a/dags/samples/airflowisms.py
+++ b/dags/samples/airflowisms.py
@@ -6,11 +6,11 @@ from airflow.models.param import Param
 from airflow.models import Variable
 from airflow.operators.python import get_current_context
 
-# from airflow.operators.python import PythonOperator
 import requests
 
 @task()
 def taskflow_test_requests():
+    """ this did not work with airflow standalone """
     resp = requests.get("https://google.com")
     resp.raise_for_status()
     return resp.status_code
@@ -44,25 +44,6 @@ def taskflow_get_admin_variables():
     return True
 
 @task()
-def taskflow_mkdir():
-    """ we have permissions inside /airflow/, but nowhere else it seems """
-    if os.path.exists("/usr/local/airflow/rikolti_data/test_dir"):
-        os.remove("/usr/local/airflow/rikolti_data/test_dir/test2.txt")
-        os.rmdir("/usr/local/airflow/rikolti_data/test_dir")
-
-    os.mkdir("/usr/local/airflow/rikolti_data/test_dir")
-    with open("/usr/local/airflow/rikolti_data/test_dir/test2.txt", "w") as f:
-        f.write("hi amy")
-    return True
-
-@task()
-def taskflow_write_to_disk():
-    """ write a file to disk """
-    with open("/usr/local/airflow/rikolti_data/test.txt", "w") as f:
-        f.write("hello world")
-    return True
-
-@task()
 def taskflow_get_env():
     """ get env variables previously set """
     startup_env = os.environ.get("ENVIRONMENT_STAGE")
@@ -92,16 +73,14 @@ def downstream_should_fail(upstream_result):
     params={
         'collection_id': Param(1, description="Collection ID")
     },
-    tags=["test"],
+    tags=["sample"],
 )
-def taskflow_test_dag():
+def sample_airflowisms():
     taskflow_test_requests()
     taskflow_params()
     taskflow_get_admin_variables()
-    taskflow_mkdir()
-    taskflow_write_to_disk()
     taskflow_get_env()
     result = fails_sometimes()
     downstream_should_fail(result)
 
-taskflow_test_dag()
+sample_airflowisms()

--- a/dags/samples/airflowisms.py
+++ b/dags/samples/airflowisms.py
@@ -51,6 +51,11 @@ def taskflow_get_env():
     return startup_env
 
 @task()
+def taskflow_print(message=None):
+    print(message)
+    return message
+
+@task()
 def fails_sometimes():
     """ sometimes this task fails """
     nowish = datetime.now().second
@@ -76,6 +81,12 @@ def downstream_should_fail(upstream_result):
     tags=["sample"],
 )
 def sample_airflowisms():
+    dag_var = "boo"
+    if os.environ.get("ENVIRONMENT_STAGE") == "dev":
+        dag_var = "foo"
+
+    taskflow_print(dag_var)
+    taskflow_print(os.environ.get("ENVIRONMENT_STAGE"))
     taskflow_test_requests()
     taskflow_params()
     taskflow_get_admin_variables()

--- a/dags/samples/docker_debug.py
+++ b/dags/samples/docker_debug.py
@@ -10,20 +10,25 @@ import docker
 
 @task()
 def get_user_and_group():
+    # Get the effective user ID of current process
     print('USER')
-    uid = os.geteuid()              # effective user ID of current process
+    uid = os.geteuid()
     print(pwd.getpwuid(uid))
 
+    # Get the effective group ID of the current process, then
+    # Get the group for given group ID
     print('GROUP')
-    gid = os.getegid()             # effective group ID of current process
-    print(grp.getgrgid(gid)) # Get group for given group ID
+    gid = os.getegid()
+    print(grp.getgrgid(gid))
 
+    # Get the process ID of the current process
     print('PROCESS')
     pid = os.getpid()
-    print(pid)                      # process ID of current process
+    print(pid)
 
+    # Get the session ID of the process with the given PID
     print('SESSION')
-    print(os.getsid(pid))           # Get the session ID of the process with the given PID
+    print(os.getsid(pid))
 
 @task()
 def inspect_socket_permissions():

--- a/dags/samples/docker_debug.py
+++ b/dags/samples/docker_debug.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from airflow.decorators import dag, task
+from airflow.providers.docker.operators.docker import DockerOperator
+
+import os
+import pwd
+import grp
+import stat
+import docker
+
+@task()
+def get_user_and_group():
+    print('USER')
+    uid = os.geteuid()              # effective user ID of current process
+    print(pwd.getpwuid(uid))
+
+    print('GROUP')
+    gid = os.getegid()             # effective group ID of current process
+    print(grp.getgrgid(gid)) # Get group for given group ID
+
+    print('PROCESS')
+    pid = os.getpid()
+    print(pid)                      # process ID of current process
+
+    print('SESSION')
+    print(os.getsid(pid))           # Get the session ID of the process with the given PID
+
+@task()
+def inspect_socket_permissions():
+    # Get the file permissions of the socket file
+    mode = os.stat("/var/run/docker.sock").st_mode
+
+    # Check if it's a socket file
+    if stat.S_ISSOCK(mode):
+        # Extract the permission bits
+        permissions = {
+            'user_read': bool(mode & stat.S_IRUSR),
+            'user_write': bool(mode & stat.S_IWUSR),
+            'user_execute': bool(mode & stat.S_IXUSR),
+            'group_read': bool(mode & stat.S_IRGRP),
+            'group_write': bool(mode & stat.S_IWGRP),
+            'group_execute': bool(mode & stat.S_IXGRP),
+            'other_read': bool(mode & stat.S_IROTH),
+            'other_write': bool(mode & stat.S_IWOTH),
+            'other_execute': bool(mode & stat.S_IXOTH),
+        }
+
+        for key, value in permissions.items():
+            print(f"{key}: {value}")
+        return "Socket file exists"
+    else:
+        return "Not a socket file"
+
+@task()
+def is_docker_running():
+    client = docker.from_env()
+    client.ping()
+    return True
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    tags=["sample"],
+)
+def docker_debug():
+
+    docker_operator_task = DockerOperator(
+        task_id="docker_operator_task",
+        image="python:3.9.18-slim-bullseye",
+        container_name="docker_operator_task",
+        command="python -c 'print(\"hello from docker operator python\")'",
+        network_mode="bridge",
+        auto_remove='force'
+    )
+    (
+        get_user_and_group() >> 
+        inspect_socket_permissions() >> 
+        is_docker_running() >> 
+        docker_operator_task
+    )
+
+docker_debug()

--- a/dags/samples/docker_operator.py
+++ b/dags/samples/docker_operator.py
@@ -47,6 +47,9 @@ def sample_docker_operators():
     # since the docker daemon is running on the host machine, we can mount
     # a folder from the host machine into the container, but we cannot mount
     # a folder from the airflow container machine into the container
+
+    # TODO: template image, version, and mount
+    # https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html#airflow-variables-in-templates
     mount_folder_task = DockerOperator(
         task_id="mount_folder_task",
         image="simple_python:latest",

--- a/dags/samples/docker_operator.py
+++ b/dags/samples/docker_operator.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from docker.types import Mount
 from airflow.decorators import dag
 from airflow.models.param import Param
 from airflow.providers.docker.operators.docker import DockerOperator
@@ -41,5 +42,27 @@ def sample_docker_operators():
         mount_tmp_dir=False,
     )
     parameterize_print_task
+
+    # https://docker-py.readthedocs.io/en/stable/api.html#docker.types.Mount
+    # since the docker daemon is running on the host machine, we can mount
+    # a folder from the host machine into the container, but we cannot mount
+    # a folder from the airflow container machine into the container
+    mount_folder_task = DockerOperator(
+        task_id="mount_folder_task",
+        image="simple_python:latest",
+        container_name="mount_folder_task_container",
+        command="--message '{{ params.message }}' --output /tmp/rikolti_data/output.txt",
+        network_mode="bridge",
+        auto_remove='force',
+        mount_tmp_dir=False,
+        mounts=[
+            Mount(
+                source="/Users/awieliczka/Projects/rikolti_data",
+                target="/tmp/rikolti_data",
+                type="bind",
+            )
+        ]
+    )
+    mount_folder_task
 
 sample_docker_operators()

--- a/dags/samples/docker_operator.py
+++ b/dags/samples/docker_operator.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from airflow.decorators import dag
+from airflow.providers.docker.operators.docker import DockerOperator
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    tags=["sample"],
+)
+def sample_docker_operators():
+    
+    docker_operator_task = DockerOperator(
+        task_id="docker_operator_task", 
+        image="simple_python:latest",
+        container_name="simple_python_container_task",
+        docker_url="unix://var/run/docker.sock",
+        network_mode="bridge",
+        auto_remove='force',
+    )
+
+    docker_operator_task
+
+sample_docker_operators()

--- a/dags/samples/docker_operator.py
+++ b/dags/samples/docker_operator.py
@@ -20,7 +20,13 @@ class SpecialDockerOperator(DockerOperator):
     schedule=None,
     start_date=datetime(2023, 1, 1),
     catchup=False,
-    params={'message': Param("hello from your dags parameters", description="message to print")},
+    params={
+        'message': 
+        Param(
+            "hello from your dags parameters", 
+            description="message to print"
+        )
+    },
     tags=["sample"],
 )
 def sample_docker_operators():
@@ -66,7 +72,10 @@ def sample_docker_operators():
         task_id="mount_folder_task",
         image="simple_python:latest",
         container_name="mount_folder_task_container",
-        command="--message '{{ params.message }}' --output /tmp/rikolti_data/output.txt",
+        command=(
+            "--message '{{ params.message }}' "
+            "--output /tmp/rikolti_data/output.txt"
+        ),
         network_mode="bridge",
         auto_remove='force',
         mount_tmp_dir=False,

--- a/dags/samples/docker_operator.py
+++ b/dags/samples/docker_operator.py
@@ -1,24 +1,45 @@
 from datetime import datetime
 from airflow.decorators import dag
+from airflow.models.param import Param
 from airflow.providers.docker.operators.docker import DockerOperator
 
 @dag(
     schedule=None,
     start_date=datetime(2023, 1, 1),
     catchup=False,
+    params={'message': Param("hello from your dags parameters", description="message to print")},
     tags=["sample"],
 )
 def sample_docker_operators():
     
-    docker_operator_task = DockerOperator(
-        task_id="docker_operator_task", 
+    basic_task = DockerOperator(
+        task_id="basic_task",
         image="simple_python:latest",
-        container_name="simple_python_container_task",
-        docker_url="unix://var/run/docker.sock",
+        container_name="basic_task_container",
         network_mode="bridge",
         auto_remove='force',
     )
+    basic_task
 
-    docker_operator_task
+    specify_print_task = DockerOperator(
+        task_id="specific_task",
+        image="simple_python:latest",
+        container_name="specific_task_container",
+        command="--message 'there are cats in here'",
+        network_mode="bridge",
+        auto_remove='force',
+    )
+    specify_print_task
+
+    parameterize_print_task = DockerOperator(
+        task_id="parameterize_task",
+        image="simple_python:latest",
+        container_name="parameterize_task_container",
+        command="--message '{{ params.message }}'",
+        network_mode="bridge",
+        auto_remove='force',
+        mount_tmp_dir=False,
+    )
+    parameterize_print_task
 
 sample_docker_operators()

--- a/dags/samples/dynamic_tasks.py
+++ b/dags/samples/dynamic_tasks.py
@@ -15,7 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Example DAG demonstrating the usage of dynamic task mapping with non-TaskFlow operators."""
+"""Example DAG demonstrating the usage of dynamic task mapping 
+with non-TaskFlow operators."""
 from __future__ import annotations
 
 from datetime import datetime
@@ -57,9 +58,11 @@ class SumItOperator(BaseOperator):
 )
 def sample_dynamic_tasks():
     # map the task to a list of values
-    add_one_task = AddOneOperator.partial(task_id="add_one").expand(value=[1, 2, 3])
+    add_one_task = AddOneOperator.partial(task_id="add_one").expand(
+        value=[1, 2, 3])
 
     # aggregate (reduce) the mapped tasks results
-    sum_it_task = SumItOperator(task_id="sum_it", values=add_one_task.output)
+    sum_it_task = SumItOperator(                            # noqa: F841
+        task_id="sum_it", values=add_one_task.output) 
 
 sample_dynamic_tasks()

--- a/dags/samples/dynamic_tasks.py
+++ b/dags/samples/dynamic_tasks.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Example DAG demonstrating the usage of dynamic task mapping with non-TaskFlow operators."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.decorators import dag
+from airflow.models.baseoperator import BaseOperator
+
+
+class AddOneOperator(BaseOperator):
+    """A custom operator that adds one to the input."""
+
+    def __init__(self, value, **kwargs):
+        super().__init__(**kwargs)
+        self.value = value
+
+    def execute(self, context):
+        return self.value + 1
+
+
+class SumItOperator(BaseOperator):
+    """A custom operator that sums the input."""
+
+    template_fields = ("values",)
+
+    def __init__(self, values, **kwargs):
+        super().__init__(**kwargs)
+        self.values = values
+
+    def execute(self, context):
+        total = sum(self.values)
+        print(f"Total was {total}")
+        return total
+
+
+@dag(
+    start_date=datetime(2022, 3, 4),
+    catchup=False,
+    tags=["sample"]
+)
+def sample_dynamic_tasks():
+    # map the task to a list of values
+    add_one_task = AddOneOperator.partial(task_id="add_one").expand(value=[1, 2, 3])
+
+    # aggregate (reduce) the mapped tasks results
+    sum_it_task = SumItOperator(task_id="sum_it", values=add_one_task.output)
+
+sample_dynamic_tasks()

--- a/dags/samples/filesystem.py
+++ b/dags/samples/filesystem.py
@@ -2,7 +2,6 @@ import os
 
 from datetime import datetime
 from airflow.decorators import dag, task
-from airflow.models.param import Param
 
 @task()
 def taskflow_mkdir():

--- a/dags/samples/filesystem.py
+++ b/dags/samples/filesystem.py
@@ -1,0 +1,36 @@
+import os
+
+from datetime import datetime
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+
+@task()
+def taskflow_mkdir():
+    """ we have permissions inside /airflow/, but nowhere else it seems """
+    if os.path.exists("/usr/local/airflow/rikolti_data/test_dir"):
+        os.remove("/usr/local/airflow/rikolti_data/test_dir/test2.txt")
+        os.rmdir("/usr/local/airflow/rikolti_data/test_dir")
+
+    os.mkdir("/usr/local/airflow/rikolti_data/test_dir")
+    with open("/usr/local/airflow/rikolti_data/test_dir/test2.txt", "w") as f:
+        f.write("hi amy")
+    return True
+
+@task()
+def taskflow_write_to_disk():
+    """ write a file to disk """
+    with open("/usr/local/airflow/rikolti_data/test.txt", "w") as f:
+        f.write("hello world")
+    return True
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    tags=["sample"],
+)
+def sample_filesystem_management():
+    taskflow_mkdir()
+    taskflow_write_to_disk()
+
+sample_filesystem_management()

--- a/dags/samples/operators.py
+++ b/dags/samples/operators.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from airflow.decorators import dag, task
+from airflow.providers.docker.operators.docker import DockerOperator
+from airflow.operators.python import PythonOperator
+
+@dag(
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    tags=["sample"],
+)
+def sample_operators():
+
+    @task()
+    def taskflow_func():
+        print("hello from taskflow task")
+
+    def python_operator_callable():
+        print("and hello from a python operator task")
+    python_op = PythonOperator(
+        task_id="python_operator",
+        python_callable=python_operator_callable,
+    )
+
+    @task.docker(
+        image="python:3",
+        auto_remove=True,
+        container_name="docker_decorated_task"
+    )
+    def docker_decorated_func():
+        print("and hello from a python:3 docker decorated task")
+
+    docker_op = DockerOperator(
+        task_id="docker_operator",
+        image="centos:latest",
+        command="echo 'hello from docker operator task'",
+        docker_url="unix://var/run/docker.sock",  # Set your docker URL
+        network_mode="bridge",
+        auto_remove="force",
+    )
+
+    # a sample chaining together the taskflow model w/ the operator model
+    taskflow_func() >> python_op >> docker_decorated_func() >> docker_op
+
+sample_operators()

--- a/dags/samples/simple_python_image/Dockerfile
+++ b/dags/samples/simple_python_image/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3
+COPY . .
+ENTRYPOINT [ "python", "hello.py" ]

--- a/dags/samples/simple_python_image/README.md
+++ b/dags/samples/simple_python_image/README.md
@@ -1,0 +1,1 @@
+$ docker build -t simple_python .

--- a/dags/samples/simple_python_image/add_one.py
+++ b/dags/samples/simple_python_image/add_one.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input', type=int, help='Input number')
+    args = parser.parse_args()
+    input = args.input
+    print(input + 1)

--- a/dags/samples/simple_python_image/hello.py
+++ b/dags/samples/simple_python_image/hello.py
@@ -4,6 +4,14 @@ if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('--message', type=str, help='Message to print')
+    parser.add_argument('--output', type=str, help='Path to output file')
     args = parser.parse_args()
     message = args.message or "Hello from docker container!"
-    print(message)
+    
+    if args.output:
+        with open(args.output, 'w') as f:
+            f.write(message)
+            f.close()
+        print(f"Message written to {args.output}")
+    else:
+        print(message)

--- a/dags/samples/simple_python_image/hello.py
+++ b/dags/samples/simple_python_image/hello.py
@@ -1,4 +1,9 @@
 # -*- coding: utf-8 -*-
 
 if __name__ == '__main__':
-    print("Hello from docker container!")
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--message', type=str, help='Message to print')
+    args = parser.parse_args()
+    message = args.message or "Hello from docker container!"
+    print(message)

--- a/dags/samples/simple_python_image/hello.py
+++ b/dags/samples/simple_python_image/hello.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+if __name__ == '__main__':
+    print("Hello from docker container!")

--- a/dags/shared_tasks.py
+++ b/dags/shared_tasks.py
@@ -116,7 +116,7 @@ class ContentHarvestDockerOperator(DockerOperator):
             mounts=None
 
         args = {
-            "image": "content_harvester:latest",
+            "image": "{{ var.value.get('content_harvester_image', 'content_harvester') }}:{{ var.value.get('content_harvester_version', 'latest') }}",
             "container_name": f"content_harvester_{collection_id}_{page}",
             "command": [f"{collection_id}", f"{page}"],
             "network_mode": "bridge",

--- a/dags/shared_tasks.py
+++ b/dags/shared_tasks.py
@@ -5,6 +5,7 @@ import requests
 from docker.types import Mount
 
 from airflow.decorators import task
+from airflow.models import Variable
 from airflow.providers.docker.operators.docker import DockerOperator
 
 from rikolti.metadata_fetcher.lambda_function import fetch_collection
@@ -115,8 +116,16 @@ class ContentHarvestDockerOperator(DockerOperator):
         if not mounts:
             mounts=None
 
+        container_image = Variable.get(
+            'content_harvester_image',
+            default_var='content_harvester'
+        )
+        container_version = Variable.get(
+            'content_harvester_version',
+            default_var='latest'
+        )
         args = {
-            "image": "{{ var.value.get('content_harvester_image', 'content_harvester') }}:{{ var.value.get('content_harvester_version', 'latest') }}",
+            "image": f"{container_image}:{container_version}",
             "container_name": f"content_harvester_{collection_id}_{page}",
             "command": [f"{collection_id}", f"{page}"],
             "network_mode": "bridge",

--- a/env.example
+++ b/env.example
@@ -12,3 +12,12 @@ export SKIP_UNDEFINED_ENRICHMENTS=True
 # export UCLDC_SOLR_URL="https://harvest-stg.cdlib.org/solr_api"    # this is solr stage
 export UCLDC_SOLR_URL="https://solr.calisphere.org/solr"            # this is solr prod
 export UCLDC_SOLR_API_KEY=                                          # ask for a key
+
+# content_harvester
+export CONTENT_DATA_SRC=file:///rikolti_data
+export CONTENT_DATA_DEST=file:///rikolti_data
+export CONTENT_DEST=file:///rikolti_content
+
+# content_harvester when run locally via aws_mwaa_local_runner
+export CONTENT_DATA_MOUNT=/Users/awieliczka/Projects/rikolti_data
+export CONTENT_MOUNT=/Users/awieliczka/Projects/rikolti_content

--- a/metadata_fetcher/settings.py
+++ b/metadata_fetcher/settings.py
@@ -12,7 +12,7 @@ load_dotenv()
 NUXEO_TOKEN = os.environ.get('NUXEO')
 FLICKR_API_KEY = os.environ.get('FLICKR_API_KEY')
 
-DATA_DEST_URL = os.environ.get("FETCHER_DATA_DEST", "file:///tmp/")
+DATA_DEST_URL = os.environ.get("FETCHER_DATA_DEST", "file:///tmp")
 DATA_DEST = {
     "STORE": urlparse(DATA_DEST_URL).scheme,
     "BUCKET": urlparse(DATA_DEST_URL).netloc,

--- a/metadata_mapper/lambda_function.py
+++ b/metadata_mapper/lambda_function.py
@@ -128,7 +128,8 @@ def map_page(collection_id: int, page_filename: str, collection: Union[dict, str
     return {
         'status': 'success',
         'num_records_mapped': len(mapped_records),
-        'page_exceptions': group_page_exceptions
+        'page_exceptions': group_page_exceptions,
+        'page_filename': page_filename,
     }
 
 

--- a/metadata_mapper/settings.py
+++ b/metadata_mapper/settings.py
@@ -6,14 +6,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-DATA_SRC_URL = os.environ.get('MAPPER_DATA_SRC', 'file:///tmp/')
+DATA_SRC_URL = os.environ.get('MAPPER_DATA_SRC', 'file:///tmp')
 DATA_SRC = {
     "STORE": urlparse(DATA_SRC_URL).scheme,
     "BUCKET": urlparse(DATA_SRC_URL).netloc,
     "PATH": urlparse(DATA_SRC_URL).path
 }
 
-DATA_DEST_URL = os.environ.get('MAPPER_DATA_DEST', 'file:///tmp/')
+DATA_DEST_URL = os.environ.get('MAPPER_DATA_DEST', 'file:///tmp')
 DATA_DEST = {
     "STORE": urlparse(DATA_DEST_URL).scheme,
     "BUCKET": urlparse(DATA_DEST_URL).netloc,


### PR DESCRIPTION
This is probably at a good point for review and evaluation. It pipes together a lot of the Dockerfile/docker-compose/mounting/DockerOperator/Airflow Variable work. 

### Docker/Airflow Integration Work:

The Content Harvester can be run as a python module (within a system with system level dependencies installed), as a docker container (recommend to use docker-compose), or as a docker operator within the `aws_mwaa_local_runner` ecosystem. This PR:

- Updates the Content Harvester's Dockerfile entrypoint to be congruent with the new import world order (`python -m content_harvester.by_page`)
- Sets up docker-compose for local development by overwriting the entrypoint, mounting `rikolti_data`, `rikolti_content`, and the source code into the container, and sets several environment variables for writing to these mounted volumes. 
- Creates a `ContentHarvesterDockerOperator` custom operator which subclasses the DockerOperator in order to package together standard DockerOperator parameters, make the `ContentHarvesterDockerOperator` importable in multiple DAGs, and make the `ContentHarvesterDockerOperator` available for dynamic fan-out with use of airflow's operator `.expand()` method. 
- `ContentHarvesterDockerOperator` uses airflow variables to specify content_harvester image name and content_harvester version (defaults to `content_harvester` and `latest`, respectively)
- `ContentHarvesterDockerOperator` manages figuring out mounts from the host machine (not the airflow container) to the content_harvester container, when run through the airflow container, via the `CONTENT_DATA_MOUNT` and `CONTENT_MOUNT` environment variables specified in `startup.sh`. This has been reflected in the README. 
- Creates a `dags/content_dag.py` containing two `ContentHarvesterDockerOperator`s, one operating to harvest content for a single page, one operating to harvest content for an entire collection (via entrypoint overwrite at the Operator level). 
- Alongside all this filesystem mounting work, there was work within the application code to update `settings.py` (and it's usage) to use the URL structure (ex: file:///path or s3://bucket/path) for `CONTENT_DATA_SRC`, `CONTENT_DATA_DEST`, and `CONTENT_DEST` environment variables. This has been reflected in the README. 

Features still requiring development work:
- TODO: had to add `chmod +x` permissions to `by_collection.py` to get that entrypoint working, but when I changed entrypoint from by_collection to by_page, I didn't update chmod - how is it working?
- TODO: there's the addition of a `get_mapped_page_filenames_task`, but this could possibly get folded into the `get_mapping_status_task`, which doesn't currently have a return value I believe. 
- deployment of content harvester container to ECR. 
- verification that the DockerOperator works as we expect in deployed MWAA context (we maybe probably need an airflow connection to the ECR repository? some roles to run the container? roles to write to s3 from the container?) with s3 `CONTENT_DATA_SRC`, `CONTENT_DATA_DEST` and `CONTENT_DEST` environment variables. 

### Content Harvester Application Work:
In addition to the changes to settings.py to get mounts all working correctly during local development, I also made the following updates to the content harvester application code: 

- https://github.com/ucldc/rikolti/pull/533/commits/f694506937090b5625dc7142bfb7b301a424ee5b - an abstraction refactor
- https://github.com/ucldc/rikolti/pull/533/commits/a370126e3b409c810488fa5344b811cb3e95fcd2 - move record-level reporting of missing thumbnails
- https://github.com/ucldc/rikolti/pull/533/commits/e9222087438d1b202b41f3bd8301de2798dc0449 - write per-page output instead of per record

I'm tempted to cherry-pick these out into a new branch dedicated to the internals of the content_harvester container. Along the way I ran into some application-level errors that were tricky to trace and wound up refactoring this codebase instead (first commit listed here). 

The second commit listed here is relatively straightforward: "Move record level reporting on missing thumbnails" allows us to report out missing thumbnails in the records that have been processed before an exception occurs and exits the process entirely. 

The third commit within the application code addresses the fact that the content_harvester was originally written to take a page of mapped metadata and spin off it's own lambda processes for each record. Each lambda process would read the record, find any described media files and/or thumbnail files, download them to the lambda's runtime environment, process them, and then upload the processed media and/or thumbnail files to their respective s3 locations before writing to s3 a revised mapped metadata record with details regarding where these files were written to. This 1:1 mapping of lambda process to record was determined due to lambda's 15 minute timeout, the indeterminate number of records per page, and the indeterminate amount of time all the network traffic of downloading from source institution and uploading to s3 might take. Since we no longer have those limitations, the third commit adjusts the code base to wait until a full page of mapped metadata records have been revised with media/thumbnail locations before writing a full page out, instead of writing out one file per record. The 1:1 file to page relationship still seems somewhat arbitrary, but this is consistent with the rest of our codebase. 

The contents of the content_harvester container still aren't quite fully featured. I started working on the internals of the content harvester some in the above commits, but then realized this PR is already looking pretty sizable. 

Features still requiring development work:
- md5 hashing of images
- s3 output
- cache optimizations

### Samples Files Isolating Airflow Concepts:
- Split up `taskflow_sample_dag` into a series of thematically related sample dags in `dags/samples/`. 
- `dags/samples/docker_debug.py` was helpful in debugging mounting the local docker socket into the airflow docker container. 
- `dags/samples/docker_operator.py` demos a simple airflow DockerOperator, with `dags/samples/simple_python_image` as the docker image. `dags/samples/docker_operator.py` also demos using jinja templating in the DockerOperator to access DAG parameters and mounting a folder from the host file system to the docker container that's run using the DockerOperator. Also demos creating a subclass of the DockerOperator for use in dynamic fan-out. 
- `dags/samples/dynamic_tasks.py` demos subclassing a BasicOperator for use in dynamic fan-out (extrapolated to a DockerOperator subclass in `dags/samples/docker_operator.py`)
- `dags/samples/airflowisms.py` demos getting an environment variable in the DAG definition and passing it into a task to validate that we can do this with the `CONTENT_DATA_MOUNT` and `CONTENT_MOUNT` environment variables. 
- `dags/samples/airflowisms.py` demos getting an airflow json variable in addition to a straightforward key:value variable. 
- `dags/samples/airflowisms.py` demos using an airflow variable in jinja templates with a BashOperator