### PR TITLE
Don't overwrite type if registry's dcmi_type is None/X

### DIFF
--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -306,6 +306,7 @@ class Record(ABC, object):
         """
         field = field[0]
         mode = mode[0]
+        field_value = None
 
         if field == "rights":
             rights = [
@@ -319,21 +320,24 @@ class Record(ABC, object):
             field_value = [r.strip() for r in rights]
 
         if field == "type":
-            field_value = [constants.dcmi_types.get(collection.get('dcmi_type'), None)]
+            field_value = constants.dcmi_types.get(
+                collection.get('dcmi_type'), None)
+            field_value = [field_value] if field_value else None
 
         if field == "title":
             field_value = ["Title unknown"]
 
-        if mode == "overwrite":
-            self.mapped_data[field] = field_value
-        elif mode == "append":
-            if field in self.mapped_data:
-                self.mapped_data[field] += (field_value)
-            else:
+        if field_value:
+            if mode == "overwrite":
                 self.mapped_data[field] = field_value
-        else:  # default is fill if empty
-            if field not in self.mapped_data:
-                self.mapped_data[field] = field_value
+            elif mode == "append":
+                if field in self.mapped_data:
+                    self.mapped_data[field] += (field_value)
+                else:
+                    self.mapped_data[field] = field_value
+            else:  # default is fill if empty
+                if field not in self.mapped_data:
+                    self.mapped_data[field] = field_value
 
         # not sure what this is about
         # if not exists(data, "@context"):


### PR DESCRIPTION
will need to re-generate validation reports for flickr, cca_vault, and diff them against existing validation reports to ensure this doesn't create new errors. 