### PR TITLE
[feat]: Validate by mapper type dag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ env.local
 .idea/
 local_settings.py
 rikolti_bucket/
+rikolti_data/
 .aws-sam/
 samconfig.toml
 /.bash_history

--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ vi env.local
 
 Currently, I only use one virtual environment, even though each folder located at the root of this repository represents an isolated component. If dependency conflicts are encountered, I'll wind up creating separate environments.
 
-Similarly, I also only use one env.local as well. Rikolti fetches data to your local system, maps that data, and then fetches relevant content files (media files, previews, and thumbnails). Set `FETCHER_DATA_DEST` to the URI where you would like Rikolti to store fetched data - Rikolti will create a folder (or s3 prefix)`vernacular_metadata` at this location. Set `MAPPER_DATA_SRC` to the URI where Rikolti can find a `vernacular_metadata` folder that contains the fetched data you're attempting to map. Set `MAPPER_DATA_DEST` to the URI where you would like Rikolti to store mapped data - Rikolti will create a folder (or s3 prefix) `mapped_metadata` at this location. Set `CONTENT_DATA_SRC` to the URI where Rikolti can find a `mapped_metadata` folder that contains the mapped metadata describing where to find content. Set `CONTENT_DATA_DEST` to the URI where you would like Rikolti to store mapped data that has been updated with pointers to content files - Rikolti will create a folder (or s3 prefix) `mapped_with_content` at this location. Set `CONTENT_DEST` to the URI where you would like Rikolti to store content files.
+Similarly, I also only use one env.local as well. Rikolti fetches data to your local system, maps that data, and then fetches relevant content files (media files, previews, and thumbnails). Set `FETCHER_DATA_DEST` to the URI where you would like Rikolti to store fetched data - Rikolti will create a folder (or s3 prefix) `<collection_id>/vernacular_metadata` at this location. Set `MAPPER_DATA_SRC` to the URI where Rikolti can find a `<collection_id>/vernacular_metadata` folder that contains the fetched data you're attempting to map. Set `MAPPER_DATA_DEST` to the URI where you would like Rikolti to store mapped data - Rikolti will create a folder (or s3 prefix) `<collection_id>/mapped_metadata` at this location. Set `CONTENT_DATA_SRC` to the URI where Rikolti can find a `<collection_id>/mapped_metadata` folder that contains the mapped metadata describing where to find content. Set `CONTENT_DATA_DEST` to the URI where you would like Rikolti to store mapped data that has been updated with pointers to content files - Rikolti will create a folder (or s3 prefix) `<collection_id>/mapped_with_content` at this location. Set `CONTENT_DEST` to the URI where you would like Rikolti to store content files.
 
 For example, one way to configure `env.local` is:
 
 ```
-FETCHER_DATA_DEST=file:///Users/awieliczka/Projects/rikolti_data
+FETCHER_DATA_DEST=file:///Users/awieliczka/Projects/rikolti/rikolti_data
 MAPPER_DATA_SRC=$FETCHER_DATA_DEST
 MAPPER_DATA_DEST=$FETCHER_DATA_DEST
 CONTENT_DATA_SRC=$FETCHER_DATA_DEST
 CONTENT_DATA_DEST=$FETCHER_DATA_DEST
-CONTENT_DEST=file:///Users/awieliczka/Projects/rikolti_content
+CONTENT_DEST=file:///Users/awieliczka/Projects/rikolti/rikolti_content
 ```
 
 Each of these can be different locations, however. For example, if you're attempting to re-run a mapper locally off of previously fetched data stored on s3, you might set `MAPPER_DATA_SRC=s3://rikolti_data`.

--- a/content_harvester/by_collection.py
+++ b/content_harvester/by_collection.py
@@ -10,7 +10,7 @@ from .by_page import harvest_page_content
 def get_mapped_pages(collection_id):
     page_list = []
     if settings.DATA_SRC['STORE'] == 'file':
-        mapped_path = settings.local_path('mapped_metadata', collection_id)
+        mapped_path = settings.local_path(collection_id, 'mapped_metadata')
         try:
             page_list = [f for f in os.listdir(mapped_path)
                             if os.path.isfile(os.path.join(mapped_path, f))]
@@ -26,7 +26,7 @@ def get_mapped_pages(collection_id):
         )
         response = s3_client.list_objects_v2(
             Bucket=settings.DATA_SRC["BUCKET"],
-            Prefix=f'mapped_metadata/{collection_id}/'
+            Prefix=f'{collection_id}/mapped_metadata/'
         )
         page_list = [obj['Key'].split('/')[-1] for obj in response['Contents']]
     return page_list

--- a/content_harvester/by_page.py
+++ b/content_harvester/by_page.py
@@ -23,14 +23,14 @@ class UnsupportedMimetype(Exception):
 def get_mapped_records(collection_id, page_filename, s3_client) -> list:
     mapped_records = []
     if settings.DATA_SRC["STORE"] == 'file':
-        local_path = settings.local_path('mapped_metadata', collection_id)
+        local_path = settings.local_path(collection_id, 'mapped_metadata')
         page_path = os.path.join(local_path, str(page_filename))
         page = open(page_path, "r")
         mapped_records = json.loads(page.read())
     else:
         page = s3_client.get_object(
             Bucket=settings.DATA_SRC["BUCKET"],
-            Key=f"mapped_metadata/{collection_id}/{page_filename}"
+            Key=f"{collection_id}/mapped_metadata/{page_filename}"
         )
         mapped_records = json.loads(page['Body'].read())
     return mapped_records
@@ -38,7 +38,7 @@ def get_mapped_records(collection_id, page_filename, s3_client) -> list:
 
 def write_mapped_record(collection_id, record, s3_client):
     if settings.DATA_DEST["STORE"] == 'file':
-        local_path = settings.local_path('mapped_with_content', collection_id)
+        local_path = settings.local_path(collection_id, 'mapped_with_content')
         if not os.path.exists(local_path):
             os.makedirs(local_path)
         
@@ -54,7 +54,7 @@ def write_mapped_record(collection_id, record, s3_client):
         upload_status = s3_client.put_object(
             Bucket=settings.DATA_DEST["BUCKET"],
             Key=(
-                f"mapped_with_content/{collection_id}/"
+                f"{collection_id}/mapped_with_content/"
                 f"{record.get('calisphere-id')}"
             ),
             Body=json.dumps(record)
@@ -64,7 +64,7 @@ def write_mapped_record(collection_id, record, s3_client):
 
 def write_mapped_page(collection_id, page, records):
     if settings.DATA_DEST["STORE"] == 'file':
-        local_path = settings.local_path('mapped_with_content', collection_id)
+        local_path = settings.local_path(collection_id, 'mapped_with_content')
         if not os.path.exists(local_path):
             os.makedirs(local_path)
         page_path = os.path.join(local_path, page)
@@ -75,7 +75,7 @@ def write_mapped_page(collection_id, page, records):
 def get_child_records(collection_id, parent_id, s3_client) -> list:
     mapped_child_records = []
     if settings.DATA_SRC["STORE"] == 'file':
-        local_path = settings.local_path('mapped_metadata', collection_id)
+        local_path = settings.local_path(collection_id, 'mapped_metadata')
         children_path = os.path.join(local_path, 'children')
 
         if os.path.exists(children_path):
@@ -88,7 +88,7 @@ def get_child_records(collection_id, parent_id, s3_client) -> list:
     else:
         child_pages = s3_client.list_objects_v2(
             Bucket=settings.DATA_SRC["BUCKET"],
-            Prefix=f"mapped_metadata/{collection_id}/children/{parent_id}"
+            Prefix=f"{collection_id}/mapped_metadata/children/{parent_id}"
         )
         for child_page in child_pages['Contents']:
             page = s3_client.get_object(

--- a/content_harvester/settings.py
+++ b/content_harvester/settings.py
@@ -42,10 +42,10 @@ CONTENT_PROCESSES = {
     'ffprobe': '/usr/bin/ffprobe',
 }
 
-def local_path(folder, collection_id):
+def local_path(collection_id, folder):
     local_path = os.sep.join([
         DATA_SRC["PATH"],
-        folder,
         str(collection_id),
+        folder,
     ])
     return local_path

--- a/content_harvester/tests.py
+++ b/content_harvester/tests.py
@@ -8,7 +8,7 @@ from .by_registry_endpoint import harvest_endpoint
 from .sample_data.nuxeo_harvests import nuxeo_complex_object_harvests
 
 def main():
-    mapped_path = settings.local_path('mapped_metadata', 0)[:-1]
+    mapped_path = settings.DATA_SRC['PATH']
     urls = [
         f"https://registry.cdlib.org/api/v1/rikoltimapper/{f}/?format=json"
         for f in os.listdir(mapped_path)

--- a/dags/validate_by_mapper_type.py
+++ b/dags/validate_by_mapper_type.py
@@ -1,0 +1,67 @@
+import requests
+from datetime import datetime
+
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+
+from rikolti.metadata_fetcher.fetch_registry_collections import fetch_endpoint
+from rikolti.metadata_mapper.map_registry_collections import map_endpoint
+from rikolti.metadata_mapper.map_registry_collections import registry_endpoint
+from rikolti.metadata_mapper.validate_mapping import create_collection_validation_csv
+
+@task()
+def make_mapper_type_endpoint(params=None):
+    if not params or not params.get('mapper_type'):
+        raise ValueError("Mapper type not found in params")
+    mapper_type = params.get('mapper_type')
+    return (
+        "https://registry.cdlib.org/api/v1/rikoltifetcher/?format=json"
+        f"&mapper_type={mapper_type}&ready_for_publication=true"
+    )
+
+@task()
+def fetch_endpoint_task(endpoint, params=None):
+    limit = params.get('limit', None) if params else None
+    return fetch_endpoint(endpoint, limit)
+
+@task()
+def map_endpoint_task(endpoint, params=None):
+    limit = params.get('limit', None) if params else None
+    return map_endpoint(endpoint, limit)
+
+@task()
+def validate_endpoint_task(url, params=None):
+    limit = params.get('limit', None) if params else None
+
+    response = requests.get(url=url)
+    response.raise_for_status()
+    total = response.json().get('meta', {}).get('total_count', 1)
+    if not limit:
+        limit = total
+
+    print(f">>> Validating {limit}/{total} collections described at {url}")
+
+    for collection in registry_endpoint(url):
+        print(f"Validating collection {collection['collection_id']}")
+        create_collection_validation_csv(collection['collection_id'])
+
+@dag(
+    dag_id="validate_by_mapper_type",
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    params={
+        'mapper_type': Param(None, description="Rikolti mapper type to harvest and validate"),
+        'limit': Param(None, description="Limit number of collections to validate"),
+    },
+    tags=["rikolti"],
+)
+def validate_by_mapper_type():
+    endpoint = make_mapper_type_endpoint()
+    (
+        fetch_endpoint_task(endpoint) >> 
+        map_endpoint_task(endpoint) >>
+        validate_endpoint_task(endpoint)
+    )
+
+validate_by_mapper_type()

--- a/harvest.sh
+++ b/harvest.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+export RIKOLTI_HOME="/Users/awieliczka/Projects/rikolti"
+source $RIKOLTI_HOME/env.local
+source ~/.envs/rikolti/bin/activate
+which python
+
+python -m metadata_fetcher.fetch_registry_collections \
+    "https://registry.cdlib.org/api/v1/rikoltifetcher/?format=json&mapper_type=$1&ready_for_publication=true" \
+    > $RIKOLTI_HOME/rikolti_data/$1_fetcher_job.csv
+echo "fetcher job finished"
+
+python -m metadata_mapper.map_registry_collections \
+    "https://registry.cdlib.org/api/v1/rikoltifetcher/?format=json&mapper_type=$1&ready_for_publication=true" \
+    > $RIKOLTI_HOME/rikolti_data/$1_mapper_job.csv
+echo "mapper job finished"
+
+ls -d $RIKOLTI_HOME/rikolti_data/*/ | \
+    while read FOLDER; do \
+        COLLECTION=$(basename $FOLDER); \
+        echo "processing $COLLECTION"; \
+        python -m metadata_mapper.validate_mapping $COLLECTION \
+            > "$RIKOLTI_HOME/rikolti_data/$COLLECTION/validation_job.txt"; \
+    done

--- a/harvest_collection.sh
+++ b/harvest_collection.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+export RIKOLTI_HOME="/Users/awieliczka/Projects/rikolti"
+source $RIKOLTI_HOME/env.local
+which python
+
+python -m metadata_fetcher.fetch_registry_collections \
+    "https://registry.cdlib.org/api/v1/rikoltifetcher/$1?format=json" \
+    > $RIKOLTI_HOME/rikolti_data/$1_fetcher_job.txt
+echo "fetcher job finished"
+
+python -m metadata_mapper.map_registry_collections \
+    "https://registry.cdlib.org/api/v1/rikoltifetcher/$1?format=json" \
+    > $RIKOLTI_HOME/rikolti_data/$1_mapper_job.txt
+echo "mapper job finished"
+
+echo "processing $1"
+python validate_mapping.py $1 \
+    > $RIKOLTI_HOME/rikolti_data/$1/validation_job.txt

--- a/metadata_fetcher/fetch_registry_collections.py
+++ b/metadata_fetcher/fetch_registry_collections.py
@@ -44,11 +44,9 @@ def fetch_endpoint(url, limit=None):
         collection_id = collection['collection_id']
 
         progress = progress + 1
-        sys.stderr.write('\r')
         progress_bar = f"{progress}/{limit}"
-        sys.stderr.write(
+        print(
             f"{progress_bar:<9}: start fetching {collection_id:<6}")
-        sys.stderr.flush()
 
         logger.debug(
             f"[{collection_id}]: call lambda with payload: {collection}")
@@ -73,16 +71,13 @@ def fetch_endpoint(url, limit=None):
                 f"{collection_id}, {fetch_result[-1]}, -, -, -, -, -")
             print(fetch_report_failure_row)
 
-        sys.stderr.write('\r')
         progress_bar = f"{progress}/{limit}"
-        sys.stderr.write(
+        print(
             f"{progress_bar:<9}: finish fetching {collection_id:<5}")
-        sys.stderr.flush()
 
         if limit and len(results.keys()) >= limit:
             break
 
-    sys.stderr.write('\n')
     return results
 
 

--- a/metadata_fetcher/fetch_registry_collections.py
+++ b/metadata_fetcher/fetch_registry_collections.py
@@ -22,21 +22,21 @@ def registry_endpoint(url):
             yield collection
 
 
-def fetch_endpoint(url, limit=None):
+def fetch_endpoint(url, limit=None, job_logger=logger):
     response = requests.get(url=url)
     response.raise_for_status()
     total = response.json().get('meta', {}).get('total_count', 1)
     progress = 0
-    fetch_report_headers = (
-        "Collection ID, Status, Total Pages, Rikolti Count, Solr Count, "
-        "Diff Count, Solr Last Updated"
-    )
+    # fetch_report_headers = (
+    #     "Collection ID, Status, Total Pages, Rikolti Count, Solr Count, "
+    #     "Diff Count, Solr Last Updated"
+    # )
 
     if not limit:
         limit = total
 
     print(f">>> Fetching {limit}/{total} collections described at {url}")
-    print(fetch_report_headers)
+    # print(fetch_report_headers)
 
     results = {}
 
@@ -45,11 +45,11 @@ def fetch_endpoint(url, limit=None):
 
         progress = progress + 1
         progress_bar = f"{progress}/{limit}"
-        print(
-            f"{progress_bar:<9}: start fetching {collection_id:<6}")
+        job_logger.debug(
+            f"{collection_id:<6}: start fetching {progress_bar} collections")
 
-        logger.debug(
-            f"[{collection_id}]: call lambda with payload: {collection}")
+        job_logger.debug(
+            f"{collection_id:<6}: call lambda with payload: {collection}")
 
         fetch_result = lambda_function.fetch_collection(collection, None)
         results[collection_id] = fetch_result
@@ -58,22 +58,31 @@ def fetch_endpoint(url, limit=None):
         total_items = sum([page['document_count'] for page in fetch_result])
         total_pages = fetch_result[-1]['page'] + 1
         diff_items = total_items - collection['solr_count']
+        diff_items_label = ""
+        if diff_items > 0:
+            diff_items_label = 'new items'
+        elif diff_items < 0:
+            diff_items_label = 'lost items'
+        else:
+            diff_items_label = 'same extent'
+
+        progress_bar = f"{progress}/{limit}"
+        job_logger.debug(
+            f"{collection_id:<6}: finish fetching {progress_bar} collections")
 
         fetch_report_row = (
-            f"{collection_id}, {'success' if success else 'error'}, "
-            f"{total_pages}, {total_items}, {collection['solr_count']}, "
-            f"{diff_items}, {collection['solr_last_updated']}"
+            f"{collection_id:<6}: {'success,' if success else 'error,':9} "
+            f"{total_pages:>4} pages, {total_items:>6} items, "
+            f"{collection['solr_count']:>6} solr items, "
+            f"{str(diff_items) + ' ' + diff_items_label + ',':>16} "
+            f"solr count last updated: {collection['solr_last_updated']}"
         )
         print(fetch_report_row)
 
         if not success:
             fetch_report_failure_row = (
-                f"{collection_id}, {fetch_result[-1]}, -, -, -, -, -")
+                f"{collection_id:<6}: {fetch_result[-1]}")
             print(fetch_report_failure_row)
-
-        progress_bar = f"{progress}/{limit}"
-        print(
-            f"{progress_bar:<9}: finish fetching {collection_id:<5}")
 
         if limit and len(results.keys()) >= limit:
             break

--- a/metadata_fetcher/fetchers/Fetcher.py
+++ b/metadata_fetcher/fetchers/Fetcher.py
@@ -32,7 +32,7 @@ class Fetcher(object):
         self.s3_data = {
             "ACL": 'bucket-owner-full-control',
             "Bucket": bucket,
-            "Key": f"vernacular_metadata/{self.collection_id}/"
+            "Key": f"{self.collection_id}/vernacular_metadata/"
         }
         if not self.collection_id:
             raise CollectionIdRequired("collection_id is required")
@@ -48,8 +48,8 @@ class Fetcher(object):
     def get_local_path(self):
         local_path = os.sep.join([
             settings.DATA_DEST["PATH"],
-            'vernacular_metadata',
             str(self.collection_id),
+            'vernacular_metadata',
         ])
         if not os.path.exists(local_path):
             os.makedirs(local_path)

--- a/metadata_mapper/lambda_shepherd.py
+++ b/metadata_mapper/lambda_shepherd.py
@@ -43,7 +43,7 @@ def get_vernacular_pages(collection_id):
 
     if settings.DATA_SRC["STORE"] == 'file':
         vernacular_path = settings.local_path(
-            'vernacular_metadata', collection_id)
+            collection_id, 'vernacular_metadata')
         try:
             page_list = [f for f in os.listdir(vernacular_path)
                          if os.path.isfile(os.path.join(vernacular_path, f))]
@@ -62,7 +62,7 @@ def get_vernacular_pages(collection_id):
         s3_client = boto3.client('s3')
         resp = s3_client.list_objects_v2(
             Bucket=settings.DATA_SRC["BUCKET"],
-            Prefix=f"vernacular_metadata/{collection_id}"
+            Prefix=f"{collection_id}/vernacular_metadata"
         )
         # TODO: check resp['IsTruncated'] and use ContinuationToken if needed
         page_list = [page['Key'] for page in resp['Contents']]

--- a/metadata_mapper/map_registry_collections.py
+++ b/metadata_mapper/map_registry_collections.py
@@ -40,11 +40,9 @@ def map_endpoint(url, limit=None):
         collection_id = collection['collection_id']
 
         progress = progress + 1
-        sys.stderr.write('\r')
         progress_bar = f"{progress}/{limit}"
-        sys.stderr.write(
+        print(
             f"{progress_bar:<9}: start mapping {collection_id:<6}\n")
-        sys.stderr.flush()
 
         logger.debug(
             f"[{collection_id}]: call lambda with collection_id: {collection_id}")
@@ -99,16 +97,13 @@ def map_endpoint(url, limit=None):
         )
         print(map_report_row)
 
-        sys.stderr.write('\r')
         progress_bar = f"{progress}/{limit}"
-        sys.stderr.write(
+        print(
             f"{progress_bar:<9}: finish mapping {collection_id:<5}")
-        sys.stderr.flush()
 
         if limit and progress >= limit:
             break
 
-    sys.stderr.write('\n')
 
 
 if __name__ == "__main__":

--- a/metadata_mapper/map_registry_collections.py
+++ b/metadata_mapper/map_registry_collections.py
@@ -26,9 +26,9 @@ def map_endpoint(url, limit=None):
     response.raise_for_status()
     total = response.json().get('meta', {}).get('total_count', 1)
     progress = 0
-    map_report_headers = (
-        "Collection ID, Status, Extent, Solr Count, Diff Count, Message"
-    )
+    # map_report_headers = (
+    #     "Collection ID, Status, Extent, Solr Count, Diff Count, Message"
+    # )
 
     if not limit:
         limit = total

--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -27,7 +27,7 @@ class UCLDCWriter(object):
 
     def write_local_mapped_metadata(self, mapped_metadata):
         local_path = settings.local_path(
-            'mapped_metadata', self.collection_id)
+            self.collection_id, 'mapped_metadata')
         if not os.path.exists(local_path):
             os.makedirs(local_path)
         page_path = os.sep.join([local_path, str(self.page_filename)])
@@ -64,7 +64,7 @@ class Vernacular(ABC, object):
 
     def get_local_api_response(self) -> str:
         local_path = settings.local_path(
-            'vernacular_metadata', self.collection_id)
+            self.collection_id, 'vernacular_metadata')
         page_path = os.sep.join([local_path, str(self.page_filename)])
         page = open(page_path, "r")
         api_response = page.read()
@@ -72,9 +72,10 @@ class Vernacular(ABC, object):
 
     def get_s3_api_response(self) -> str:
         s3_client = boto3.client('s3')
-        if not self.page_filename.startswith('vernacular_metadata'):
+        if not self.page_filename.startswith(
+            f'{self.collection_id}/vernacular_metadata'):
             self.page_filename = (
-                f"vernacular_metadata/{self.collection_id}/"
+                f"{self.collection_id}/vernacular_metadata/"
                 f"{self.page_filename}"
             )
 

--- a/metadata_mapper/mappers/oai/oai_mapper.py
+++ b/metadata_mapper/mappers/oai/oai_mapper.py
@@ -128,7 +128,7 @@ class OaiVernacular(Vernacular):
     # so use 'rb' mode
     def get_local_api_response(self):
         local_path = settings.local_path(
-            'vernacular_metadata', self.collection_id)
+            self.collection_id, 'vernacular_metadata')
         page_path = os.sep.join([local_path, str(self.page_filename)])
         page = open(page_path, "rb")
         api_response = page.read()

--- a/metadata_mapper/settings.py
+++ b/metadata_mapper/settings.py
@@ -26,10 +26,10 @@ SOLR_URL = os.environ.get('UCLDC_SOLR_URL', False)
 SOLR_API_KEY = os.environ.get('UCLDC_SOLR_API_KEY', False)
 COUCH_URL = os.environ.get('UCLDC_COUCH_URL', False)
 
-def local_path(folder, collection_id):
+def local_path(collection_id, folder):
     local_path = os.sep.join([
         DATA_SRC["PATH"],
-        folder,
         str(collection_id),
+        folder,
     ])
     return local_path

--- a/metadata_mapper/tests.py
+++ b/metadata_mapper/tests.py
@@ -16,8 +16,7 @@ from .validate_registry_collections import validate_endpoint
 
 
 def main():
-    vernacular_path = settings.local_path(
-        'vernacular_metadata', 0)[:-1]
+    vernacular_path = settings.DATA_SRC["PATH"]
     urls = [
         f"https://registry.cdlib.org/api/v1/rikoltimapper/{f}/?format=json"
         for f in os.listdir(vernacular_path)

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -49,7 +49,7 @@ def validate_collection(collection_id: int,
                                     log_level = log_level,
                                     verbose = verbose)
 
-    for page_id in utilities.get_files("mapped_metadata", collection_id):
+    for page_id in utilities.get_files(collection_id, "mapped_metadata"):
         validate_page(collection_id, page_id, validator)
 
     return validator

--- a/metadata_mapper/validate_registry_collections.py
+++ b/metadata_mapper/validate_registry_collections.py
@@ -59,7 +59,7 @@ def validate_endpoint(url):
                 continue
             results.append(collection_validation)
 
-            validation_path = settings.local_path('validation', collection_id)
+            validation_path = settings.local_path(collection_id, 'validation')
             if not os.path.exists(validation_path):
                 os.makedirs(validation_path)
             page_path = os.sep.join([

--- a/metadata_mapper/validator/validation_log.py
+++ b/metadata_mapper/validator/validation_log.py
@@ -127,7 +127,7 @@ class ValidationLog:
             filename = f"{datetime.now().strftime('%m-%d-%YT%H:%M:%S')}.csv"
 
         file_location = utilities.write_to_bucket(
-            "validation", collection_id, filename,
+            collection_id, "validation", filename,
             self._csv_content_string(include_fields))
         
         return file_location

--- a/record_indexer/by_collection.py
+++ b/record_indexer/by_collection.py
@@ -47,7 +47,7 @@ def get_metadata(collection_id, filename):
         #     settings.S3_BUCKET,
         #     f"mapped_with_content/{collection_id}/{filename}",
         #     (
-        #         "/usr/local/dev/rikolti/rikolti_bucket/mapped_with_content/"
+        #         "/usr/local/dev/rikolti/rikolti_data/mapped_with_content/"
         #         f"{collection_id}/{filename}"
         #     )
         # )

--- a/record_indexer/by_collection.py
+++ b/record_indexer/by_collection.py
@@ -11,7 +11,7 @@ def get_file_list(collection_id):
     file_list = []
 
     if settings.DATA_SRC == 'local':
-        path = settings.local_path('mapped_with_content', collection_id)
+        path = settings.local_path(collection_id, 'mapped_with_content')
         try:
             file_list = [f for f in os.listdir(path)
                             if os.path.isfile(os.path.join(path, f))]
@@ -28,7 +28,7 @@ def get_file_list(collection_id):
         )
         response = s3_client.list_objects_v2(
             Bucket=settings.S3_BUCKET,
-            Prefix=f'mapped_with_content/{collection_id}/'
+            Prefix=f'{collection_id}/mapped_with_content/'
         )
         file_list = [obj['Key'].split('/')[-1] for obj in response['Contents']]
 
@@ -39,16 +39,16 @@ def get_metadata(collection_id, filename):
     # TODO: instantiate one boto3 client and pass it around
     if settings.DATA_SRC == 'local':
         local_path = settings.local_path(
-            'mapped_with_content', collection_id)
+            collection_id, 'mapped_with_content')
         path = os.path.join(local_path, str(filename))
         file = open(path, "r")
         record = json.loads(file.read())
         # s3_client.download_file(
         #     settings.S3_BUCKET,
-        #     f"mapped_with_content/{collection_id}/{filename}",
+        #     f"{collection_id}/mapped_with_content/{filename}",
         #     (
-        #         "/usr/local/dev/rikolti/rikolti_data/mapped_with_content/"
-        #         f"{collection_id}/{filename}"
+        #         "/usr/local/dev/rikolti/rikolti_data/{collection_id}/"
+        #         f"{mapped_with_content}/{filename}"
         #     )
         # )
     else:
@@ -61,7 +61,7 @@ def get_metadata(collection_id, filename):
         )
         file = s3_client.get_object(
             Bucket=settings.S3_BUCKET,
-            Key=f"mapped_with_content/{collection_id}/{filename}"
+            Key=f"{collection_id}/mapped_with_content/{filename}"
         )
         record = json.loads(file['Body'].read())
     

--- a/record_indexer/settings.py
+++ b/record_indexer/settings.py
@@ -19,7 +19,7 @@ def local_path(folder, collection_id):
     parent_dir = os.sep.join(os.getcwd().split(os.sep)[:-1])
     local_path = os.sep.join([
         parent_dir,
-        'rikolti_bucket',
+        'rikolti_data',
         folder,
         str(collection_id),
     ])


### PR DESCRIPTION
This PR re-orders the `rikolti_data` folder, adds a `harvest.sh` and `harvest_collection.sh` scripts at the root of the directory (we can remove that `rikolti_bucket_template` branch now - a bucket template is no longer necessary), and adds a DAG to validate by mapper type which performs fetching, mapping, and validating tasks. 

The validate by mapper type dag can take a limit parameter (optional). If none is provided, it validates all collections of that mapper type. If a limit is provided, it validates up to the limit in the order the collections are provided by the registry api. 

This is fully functional but missing some obvious UI pieces, described below, as well as some scalability pieces - notes for myself as much as anyone else: 

Still required to get up and running:
- set up Adrian, Christine, and Gabriela with access to the rikolti_data s3 bucket and set up all tasks to output the s3 url of the rikolti_data OR
- make s3 bucket publicly accessible and set up all tasks to output the s3 url of the rikolti_data OR
- set up a copy s3 to google drive task (research the airflow operator, figure out how this should function)

I think the 3rd option is best, though I'm always skeptical about dealing with Google Drive API and authentication issues and I've not yet researched this. 

Next steps: 
- add an offset parameter to the validate by mapper type dag. 
- add a copy s3 to google drive task to move folders to google drive
- fix `rikolti.validator.validate` so it correctly adds missing records to the validation file instead of the job's log output, set up the validate_endpoint_task output the s3 url of the validation reports it's creating. 
- move solr and couch environment variables into airflow variables so Adrian, Christine, and Gabriela can easily and self-service switch between running validation jobs against solr/couch-stg and solr/couch-prd (how does this impact local development?)
- add dates to folders within the `rikolti_data` folder, ex: `rikolti_data/3433-2023_10_18/vernacular_metadata-3433-2023_10_18`, hook this in to <component>_data_src, <component>_data_dest options - maybe create a `RikoltiStorage` class that handles s3 vs. file storage generically that can be used throughout Rikolti - effectively wrapping boto s3 client. once a RikoltiStorage class is in place, we can define in one place how to assign dates (date + time for everything? just date? date + count - ie: `2023_10_18_run_1`, `2023_10_18_run_2`) and how to reference dates (always use most recent unless otherwise specified - what kind of hook to build in order to specify?)