### PR TITLE
Ensure start and end dates work with strs

### DIFF
--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -1592,8 +1592,15 @@ class Record(ABC, object):
 
             if record.get('date'):
                 date_source = record.get('date', None)
+
+                #  Coerce a string into a dict
+                if isinstance(date_source, str):
+                    date_source = {"begin": date_source}
+
+                #  Wrap a dict in a list
                 if isinstance(date_source, dict):
                     date_source = [date_source]
+
                 dates_start = [make_datetime(dt.get("begin"))
                                for dt in date_source if dt.get("begin")]
                 dates_start = sorted(filter(None, dates_start))


### PR DESCRIPTION
This is a quick fix to unblock @christinklez. This code takes a string date, and turns it into a dictionary, which is handled properly. I haven't tested this against all ucd_json collections.

I had only tested this updated date handling code against blacklight, which stores dates in a list of dictionaries. ucd_json stores dates in a string, which was resulting in an error. It's a bit of a challenge to make code modifications in the mapper because you want it to work for all mappers, but you don't want that need to preclude code improvements (obviously that's subjective). Apologies for this oversight.

@amywieliczka @barbarahui 
