### PR TITLE
Remove coverage field mapping in blacklight

### DIFF
--- a/metadata_mapper/mappers/ucsd_blacklight/ucsd_blacklight_mapper.py
+++ b/metadata_mapper/mappers/ucsd_blacklight/ucsd_blacklight_mapper.py
@@ -17,7 +17,6 @@ class UcsdBlacklightMapper(Record):
             "stateLocatedIn": {"name": "California"},
             "extent": self.source_metadata.get("extent_json_tesim"),
             "publisher": self.source_metadata.get("publisher_json_tesim"),
-            "coverage": self.source_metadata.get("geographic_tesim"),
             "creator": self.map_creator,
             "date": self.map_date,
             "description": self.map_description,


### PR DESCRIPTION
As it turns out, it wasn't affecting the resulting solr doc because the spatial field was being copied into it when it was created. In any case, it should be removed.