### PR TITLE
[bug]: Remove value parameter to unset_prop

### DIFF
--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -820,7 +820,7 @@ class Record(ABC, object):
         self.mapped_data[prop] = value
         return self
 
-    def unset_prop(self, prop, value):
+    def unset_prop(self, prop):
         """
         unset_prop is called with a prop, condition, and condition_prop. We
         don't ever use condition or condition_prop so I've not implemented


### PR DESCRIPTION
I think this was just a bad migration. Here's the original unset_prop implementation: https://github.com/calisphere-legacy-harvester/dpla-ingestion/blob/cfe3dcb06008c0c6cb9d8207fe28bfaa1a855e4f/lib/akamod/set_prop.py#L63 and here's the blame for the unset_prop function signature: https://github.com/ucldc/rikolti/commit/1a17e423d24eae2bf7eb454c036c19ddc6140dcb 

...I think I must have copied the set_prop function signature to the unset_prop function signature? the fact that "value" is omitted in the analysis of how the enrichment chain calls this enrichment (https://github.com/ucldc/rikolti/blob/main/metadata_mapper/mappers/mapper.py#L829-L831) suggests that "value" just shouldn't even be there. 