### PR TITLE
Feat: Bulk harvest collections by registry API url, mapper_type, or rikolti_mapper_type

### DIFF
--- a/dags/dev_validate_by_mapper_type_to_gdrive.py
+++ b/dags/dev_validate_by_mapper_type_to_gdrive.py
@@ -30,11 +30,12 @@ logger = logging.getLogger("airflow.task")
                                "use mapper_type, rikolti_mapper_type, OR "
                                "endpoint")),
         'registry_api_queryset': Param(
-            None, description=("Registry endpoint to harvest and validate"
+            None, description=("Registry endpoint to harvest and validate; "
                                "use mapper_type, rikolti_mapper_type, OR "
                                "endpoint")),
         'limit': Param(
             None, description="Limit number of collections to validate"),
+        'offset': Param(None, description="Position to start at")
     },
     tags=["dev"],
 )

--- a/dags/dev_validate_by_mapper_type_to_gdrive.py
+++ b/dags/dev_validate_by_mapper_type_to_gdrive.py
@@ -21,8 +21,20 @@ logger = logging.getLogger("airflow.task")
     start_date=datetime(2023, 1, 1),
     catchup=False,
     params={
-        'mapper_type': Param(None, description="Rikolti mapper type to harvest and validate"),
-        'limit': Param(None, description="Limit number of collections to validate"),
+        'mapper_type': Param(
+            None, description=("Legacy mapper type to harvest and validate; "
+                               "use mapper_type, rikolti_mapper_type, OR "
+                               "endpoint")),
+        'rikolti_mapper_type': Param(
+            None, description=("Rikolti mapper type to harvest and validate; "
+                               "use mapper_type, rikolti_mapper_type, OR "
+                               "endpoint")),
+        'registry_api_queryset': Param(
+            None, description=("Registry endpoint to harvest and validate"
+                               "use mapper_type, rikolti_mapper_type, OR "
+                               "endpoint")),
+        'limit': Param(
+            None, description="Limit number of collections to validate"),
     },
     tags=["dev"],
 )

--- a/dags/utils_by_mapper_type.py
+++ b/dags/utils_by_mapper_type.py
@@ -27,12 +27,12 @@ def make_mapper_type_endpoint(params=None):
                          "either a mapper_type, a rikolti_mapper_type, or a "
                          "registry_api_queryset")
 
-    which_arg = args.keys()
-    if len(arg_keys) > 1:
+    which_arg = list(args.keys())
+    if len(which_arg) > 1:
         raise ValueError("Please provide only one of mapper_type, "
                          "rikolti_mapper_type, or registry_api_queryset")
 
-    which_arg = arg_keys[0]
+    which_arg = which_arg[0]
     if which_arg == 'mapper_type':
         mapper_type = params.get('mapper_type')
         endpoint = (
@@ -53,6 +53,10 @@ def make_mapper_type_endpoint(params=None):
     else:
         raise ValueError(
             "Please provide a mapper_type, rikolti_mapper_type, or endpoint")
+
+    offset = params.get('offset')
+    if offset:
+        endpoint = endpoint + "&offset={offset}"
 
     print("Fetching, mapping, and validating collections listed at: ")
     print(endpoint)

--- a/dags/validate_by_mapper_type.py
+++ b/dags/validate_by_mapper_type.py
@@ -19,9 +19,20 @@ logger = logging.getLogger("airflow.task")
     start_date=datetime(2023, 1, 1),
     catchup=False,
     params={
-        'mapper_type': Param(None,
-                             description="Legacy mapper type to harvest and validate"),
-        'limit': Param(None, description="Limit number of collections to validate"),
+        'mapper_type': Param(
+            None, description=("Legacy mapper type to harvest and validate; "
+                               "use mapper_type, rikolti_mapper_type, OR "
+                               "endpoint")),
+        'rikolti_mapper_type': Param(
+            None, description=("Rikolti mapper type to harvest and validate; "
+                               "use mapper_type, rikolti_mapper_type, OR "
+                               "endpoint")),
+        'registry_api_queryset': Param(
+            None, description=("Registry endpoint to harvest and validate"
+                               "use mapper_type, rikolti_mapper_type, OR "
+                               "endpoint")),
+        'limit': Param(
+            None, description="Limit number of collections to validate"),
     },
     tags=["rikolti"],
 )

--- a/dags/validate_by_mapper_type.py
+++ b/dags/validate_by_mapper_type.py
@@ -28,11 +28,12 @@ logger = logging.getLogger("airflow.task")
                                "use mapper_type, rikolti_mapper_type, OR "
                                "endpoint")),
         'registry_api_queryset': Param(
-            None, description=("Registry endpoint to harvest and validate"
+            None, description=("Registry endpoint to harvest and validate; "
                                "use mapper_type, rikolti_mapper_type, OR "
                                "endpoint")),
         'limit': Param(
             None, description="Limit number of collections to validate"),
+        'offset': Param(None, description="Position to start at")
     },
     tags=["rikolti"],
 )


### PR DESCRIPTION
This updates the bulk harvesting DAG to run by mapper_type, rikolti_mapper_type, or an arbitrary queryset of collections defined by a Registry API URL. 

It also adds offset capabilities - making it so that we can run the harvester for limited subsets of collections defined at a queryset, and then offset to the next limited subset. 