### PR TITLE
Bug: Validator improvements

### DIFF
--- a/metadata_mapper/mappers/flickr/flickr_mapper.py
+++ b/metadata_mapper/mappers/flickr/flickr_mapper.py
@@ -134,7 +134,6 @@ class FlickrValidator(Validator):
         self.add_validatable_field(
             field="is_shown_by",
             validations=[
-                Validator.required_field,
                 Validator.verify_type(str),
                 FlickrValidator.content_match_regex
             ]

--- a/metadata_mapper/mappers/oai/cca_vault_mapper.py
+++ b/metadata_mapper/mappers/oai/cca_vault_mapper.py
@@ -43,7 +43,6 @@ class CcaVaultValidator(Validator):
             {
                 "field": "is_shown_by",
                 "validations": [
-                    Validator.required_field,
                     CcaVaultValidator.str_match_ignore_url_protocol,
                     Validator.verify_type(str)
                 ]

--- a/metadata_mapper/mappers/oai/chapman_mapper.py
+++ b/metadata_mapper/mappers/oai/chapman_mapper.py
@@ -89,7 +89,6 @@ class ChapmanValidator(Validator):
         self.add_validatable_field(
             field="is_shown_by",
             validations=[
-                Validator.required_field,
                 ChapmanValidator.str_match_ignore_url_protocol,
                 Validator.verify_type(str),
             ]

--- a/metadata_mapper/validator/validator.py
+++ b/metadata_mapper/validator/validator.py
@@ -666,7 +666,6 @@ default_validatable_fields: list[dict[str, Any]] = [
     {
         "field": "is_shown_by",
         "validations": [
-                        Validator.required_field,
                         Validator.content_match,
                         Validator.verify_type(str)
                         ]

--- a/metadata_mapper/validator/validator.py
+++ b/metadata_mapper/validator/validator.py
@@ -562,7 +562,7 @@ class Validator:
             "&wt=json&indent=true"
         )
         couch = f"/couchdb/_utils/document.html?ucldc/{self.key}"
-        calisphere = f"/search/?q={urllib.parse.quote_plus(self.key)}"
+        calisphere = f'/search/?q="{urllib.parse.quote_plus(self.key)}"'
 
         return {
             "key": self.key,

--- a/metadata_mapper/validator/validator.py
+++ b/metadata_mapper/validator/validator.py
@@ -139,7 +139,7 @@ class Validator:
         Returns: dict[str, bool]
         """
         return {
-            field["field"]: self.add_validatable_field(field)
+            field["field"]: self.add_validatable_field(**field)
             for field in fields
         }
 


### PR DESCRIPTION
- make `is_shown_by` optional
- add_validatable_fields is a recent addition from Tim to bulk add validation definitions, but there was a small type-based typo preventing it from working correctly
- calisphere links in the validation reports weren't working due to quoting issues