### PR TITLE
OAI updates

### DIFF
--- a/metadata_mapper/mappers/constants.py
+++ b/metadata_mapper/mappers/constants.py
@@ -155,6 +155,7 @@ type_map = {
     "writing": "text",
     "manuscript": "text",
     "yearbook": "text", # for for pspl 26715
+    "scrapbook": "text", # for quartex 23760
     "school yearbook": "text", # for islandora 26601
     "equipment": "image",
     "cartographic": "image",
@@ -188,7 +189,8 @@ format_map = {
     "mail art": "image",
     "postcard": "image",
     "image": "image",
-    "still image": "image"
+    "still image": "image",
+    "photographic postcard": "image" # fix for 27845 quartex
 }
 imt_types = ['application', 'audio', 'image', 'message', 'model',
              'multipart', 'text', 'video']

--- a/metadata_mapper/mappers/constants.py
+++ b/metadata_mapper/mappers/constants.py
@@ -88,7 +88,7 @@ scdl_fix_format = {
 type_map = {
     "photographs": "image",
     "photograph": "image",
-    "photographic prints": "image",
+    "photographic print": "image",    # fix for islandora 
     "sample book": "image",
     "ambrotype": "image",
     "carte-de-visite": "image",
@@ -155,6 +155,7 @@ type_map = {
     "writing": "text",
     "manuscript": "text",
     "yearbook": "text", # for for pspl 26715
+    "school yearbook": "text", # for islandora 26601
     "equipment": "image",
     "cartographic": "image",
     "notated music": "image",

--- a/metadata_mapper/mappers/constants.py
+++ b/metadata_mapper/mappers/constants.py
@@ -88,6 +88,7 @@ scdl_fix_format = {
 type_map = {
     "photographs": "image",
     "photograph": "image",
+    "photographic prints": "image",
     "sample book": "image",
     "ambrotype": "image",
     "carte-de-visite": "image",
@@ -153,6 +154,7 @@ type_map = {
     "correspondence": "text",
     "writing": "text",
     "manuscript": "text",
+    "yearbook": "text", # for for pspl 26715
     "equipment": "image",
     "cartographic": "image",
     "notated music": "image",

--- a/metadata_mapper/mappers/oai/islandora_mapper.py
+++ b/metadata_mapper/mappers/oai/islandora_mapper.py
@@ -1,12 +1,28 @@
 import requests
+from typing import Union, Optional, Any
+
 from requests.adapters import HTTPAdapter, Retry
 
 from .oai_mapper import OaiRecord, OaiVernacular
+from ..mapper import Validator
 
 
 class IslandoraRecord(OaiRecord):
     # https://github.com/calisphere-legacy-harvester/dpla-ingestion/blob/ucldc/lib/mappers/islandora_oai_dc_mapper.py
     # https://github.com/ucldc/harvester/blob/master/harvester/fetcher/oai_fetcher.py
+    def UCLDC_map(self):
+        return {
+            'spatial': self.map_spatial
+        }
+
+    def map_spatial(self) -> Union[list[str], None]:
+        spatial = self.collate_fields(["coverage", "spatial"])()
+        spatial = [s for s in spatial if s]
+        split_spatial = []
+        for value in spatial:
+            split_spatial.extend(value.split(';'))
+
+        return [val.strip() for val in split_spatial if val]
 
     def map_subject(self):
         # https://github.com/calisphere-legacy-harvester/dpla-ingestion/blob/ucldc/lib/mappers/dublin_core_mapper.py#L117-L127
@@ -68,5 +84,62 @@ class IslandoraRecord(OaiRecord):
         return thumb_url
 
 
+class IslandoraValidator(Validator):
+    def setup(self):
+        self.add_validatable_fields([{
+            "field": "identifier",
+            "validations": [
+                            IslandoraValidator.order_and_space_insensitive_dedupe_match,
+                            Validator.verify_type(Validator.list_of(str))
+                            ],
+        },{
+        "field": "rights",
+        "validations": [
+                        IslandoraValidator.rights_match_ignore_suffix,
+                        Validator.verify_type(Validator.list_of(str))
+                        ]
+        }])
+
+    @staticmethod
+    def order_and_space_insensitive_dedupe_match(
+            validation_def: dict, rikolti_value: Any,
+            comparison_value: Any
+        ) -> Optional[str]:
+        """
+        matches ['islandora:52_0', 'filename: cartaz_030', 'islandora: 52_0']
+        with    ['filename: cartaz_030', 'islandora: 52_0']"""
+        if sorted(rikolti_value) == sorted(comparison_value):
+            return None
+
+        rikolti_value = [v.replace(" ", "") for v in rikolti_value]
+        comparison_value = [v.replace(" ", "") for v in comparison_value]
+        if (
+            sorted(list(set(rikolti_value))) == 
+            sorted(list(set(comparison_value)))
+        ):
+            return None
+
+        return "Content mismatch"
+
+    @staticmethod
+    def rights_match_ignore_suffix(validation_def: dict, rikolti_value: Any,
+                                   comparison_value: Any) -> Optional[str]:
+        suffix = (
+            " For more information on copyright or permissions for this "
+            "image, please contact San Jose State University Special "
+            "Collections & Archives department. "
+            "http://www.sjlibrary.org/research/special/special_coll/index.htm"
+        )
+        if rikolti_value == comparison_value:
+            return None
+        if (
+            rikolti_value and len(rikolti_value) == 1 and 
+            comparison_value and len(comparison_value) == 1 and
+            rikolti_value[0] + suffix == comparison_value[0]
+        ):
+            return None
+        return "Content mismatch"
+
 class IslandoraVernacular(OaiVernacular):
     record_cls = IslandoraRecord
+    validator = IslandoraValidator

--- a/metadata_mapper/mappers/oai/omeka/csa_mapper.py
+++ b/metadata_mapper/mappers/oai/omeka/csa_mapper.py
@@ -1,12 +1,28 @@
+from typing import Union
+
 from ..omeka_mapper import OmekaRecord, OmekaVernacular
 
 
 class CsaRecord(OmekaRecord):
+    def UCLDC_map(self):
+        return {
+            'spatial': self.map_spatial
+        }
+
     def map_is_shown_by(self):
         identifiers = [i for i
                        in filter(None, self.source_metadata.get('identifier', []))
                        if 'files/original' in i]
         return identifiers[0] if identifiers else None
+
+    def map_spatial(self) -> Union[list[str], None]:
+        spatial = self.collate_fields(["coverage", "spatial"])()
+        spatial = [s for s in spatial if s]
+        split_spatial = []
+        for value in spatial:
+            split_spatial.extend(value.split(';'))
+
+        return [val.strip() for val in split_spatial if val]
 
 
 class CsaVernacular(OmekaVernacular):

--- a/metadata_mapper/mappers/oai/omeka_mapper.py
+++ b/metadata_mapper/mappers/oai/omeka_mapper.py
@@ -15,8 +15,16 @@ class OmekaRecord(OaiRecord):
     def UCLDC_map(self):
         return {
             "identifier": self.map_identifier,
-            "dateCopyrighted": self.source_metadata.get('dateCopyrighted'),
+            "dateCopyrighted": self.map_rights_date,
         }
+
+    def map_rights_date(self):
+        dateCopyrighted = self.source_metadata.get('dateCopyrighted')
+        if dateCopyrighted:
+            if isinstance(dateCopyrighted, list):
+                return dateCopyrighted[0]
+            elif isinstance(dateCopyrighted, str):
+                return dateCopyrighted
 
     def map_is_shown_at(self):
         identifiers = [i for i in filter(None, self.source_metadata.get('identifier'))

--- a/metadata_mapper/mappers/oai/omeka_mapper.py
+++ b/metadata_mapper/mappers/oai/omeka_mapper.py
@@ -15,6 +15,7 @@ class OmekaRecord(OaiRecord):
     def UCLDC_map(self):
         return {
             "identifier": self.map_identifier,
+            "dateCopyrighted": self.source_metadata.get('dateCopyrighted'),
         }
 
     def map_is_shown_at(self):

--- a/metadata_mapper/mappers/oai/pspl_mapper.py
+++ b/metadata_mapper/mappers/oai/pspl_mapper.py
@@ -7,6 +7,11 @@ from ..mapper import Validator
 
 
 class PsplRecord(OaiRecord):
+    def UCLDC_map(self):
+        return {
+            "type": self.split_and_flatten("type")
+        }
+
     def map_is_shown_by(self):
         identifier = self.source_metadata.get('id')
         if ':' not in identifier:

--- a/metadata_mapper/mappers/oai/quartex_mapper.py
+++ b/metadata_mapper/mappers/oai/quartex_mapper.py
@@ -10,6 +10,7 @@ class QuartexRecord(OaiRecord):
 
     def map_spatial(self) -> Union[list[str], None]:
         spatial = self.collate_fields(["coverage", "spatial"])()
+        spatial = [s for s in spatial if s]
         split_spatial = []
         for value in spatial:
             split_spatial.extend(value.split(';'))

--- a/metadata_mapper/mappers/oai/quartex_mapper.py
+++ b/metadata_mapper/mappers/oai/quartex_mapper.py
@@ -2,7 +2,7 @@ from typing import Union, Any, Optional
 
 from .oai_mapper import OaiRecord, OaiVernacular
 from ..mapper import Validator
-from ...validator import ValidationLogLevel, ValidationMode
+from ...validator import ValidationLogLevel
 
 
 class QuartexRecord(OaiRecord):
@@ -17,7 +17,7 @@ class QuartexRecord(OaiRecord):
         languages = self.source_metadata.get("language")
         if not isinstance(languages, list):
             languages = [languages]
-        languages = [l for l in languages if l]
+        languages = [language for language in languages if language]
         split_languages = []
         for value in languages:
             split_languages.extend(value.split(';'))

--- a/metadata_mapper/mappers/oai/quartex_mapper.py
+++ b/metadata_mapper/mappers/oai/quartex_mapper.py
@@ -1,12 +1,28 @@
-from typing import Union
+from typing import Union, Any, Optional
+
 from .oai_mapper import OaiRecord, OaiVernacular
+from ..mapper import Validator
+from ...validator import ValidationLogLevel, ValidationMode
 
 
 class QuartexRecord(OaiRecord):
     def UCLDC_map(self):
         return {
-            'spatial': self.map_spatial
+            'spatial': self.map_spatial,
+            'language': self.map_language,
+            'contributor': self.split_and_flatten("contributor"),
         }
+
+    def map_language(self) -> list:
+        languages = self.source_metadata.get("language")
+        if not isinstance(languages, list):
+            languages = [languages]
+        languages = [l for l in languages if l]
+        split_languages = []
+        for value in languages:
+            split_languages.extend(value.split(';'))
+
+        return [val.strip() for val in split_languages if val]
 
     def map_spatial(self) -> Union[list[str], None]:
         spatial = self.collate_fields(["coverage", "spatial"])()
@@ -64,5 +80,80 @@ class QuartexRecord(OaiRecord):
         # return candidates[-1].replace("Size2", "Size4")
 
 
+class QuartexValidator(Validator):
+
+    def setup(self):
+        self.add_validatable_fields([
+            {
+                "field": "creator",
+                "validations": [QuartexValidator.match_trailing_periods],
+                "level": ValidationLogLevel.WARNING,
+            },
+            {
+                "field": "contributor",
+                "validations": [QuartexValidator.match_trailing_periods],
+                "level": ValidationLogLevel.WARNING,
+            },
+            {
+                "field": "description",
+                "validations": [QuartexValidator.match_trailing_space],
+                "level": ValidationLogLevel.WARNING,
+            }
+        ])
+
+
+    @staticmethod
+    def match_trailing_periods(validation_def: dict,
+                               rikolti_value: Any,
+                               comparison_value: Any) -> Optional[str]:
+        """
+        Matches solr values ["Wieliczka, Amy L"] with rikolti values ["Wieliczka, Amy L."]
+        """
+        if rikolti_value == comparison_value:
+            return
+
+        if (
+            rikolti_value and comparison_value and 
+            len(rikolti_value) == len(comparison_value)
+        ):
+            rikolti_value = sorted(rikolti_value)
+            comparison_value = sorted(comparison_value)
+            for i in range(len(rikolti_value)):
+                if (
+                    rikolti_value[i] != comparison_value[i] and
+                    rikolti_value[i] != comparison_value[i] + '.'
+                ):
+                    return "Content mismatch"
+            return
+
+        return "Content mismatch"
+
+    @staticmethod
+    def match_trailing_space(validation_def: dict,
+                             rikolti_value: Any,
+                             comparison_value: Any) -> Optional[str]:
+        """
+        Matches solr values ["Wieliczka, Amy L"] with rikolti values ["Wieliczka, Amy L "]
+        """
+        if rikolti_value == comparison_value:
+            return
+
+        if (
+            rikolti_value and comparison_value and 
+            len(rikolti_value) == len(comparison_value)
+        ):
+            rikolti_value = sorted(rikolti_value)
+            comparison_value = sorted(comparison_value)
+            for i in range(len(rikolti_value)):
+                if (
+                    rikolti_value[i] != comparison_value[i] and
+                    rikolti_value[i] + ' ' != comparison_value[i]
+                ):
+                    return "Content mismatch"
+            return
+
+        return "Content mismatch"
+
 class QuartexVernacular(OaiVernacular):
     record_cls = QuartexRecord
+    validator = QuartexValidator

--- a/metadata_mapper/mappers/oai/samvera_mapper.py
+++ b/metadata_mapper/mappers/oai/samvera_mapper.py
@@ -129,14 +129,20 @@ class SamveraValidator(Validator):
         """
         if rikolti_value == comparison_value:
             return
-        new_phone_number = '(310) 825-4988'
-        if comparison_value and len(comparison_value) == 2:
-            new_comparison_value = re.sub(
+
+
+        def sub_phone_number(rights: str) -> str:
+            return re.sub(
                 r'\(310\) 825-\d{4}',   # old phone number regex
-                new_phone_number,
-                comparison_value[1]
+                '(310) 825-4988',       # new phone number
+                rights
             )
-            comparison_value[1] = new_comparison_value
+
+        if comparison_value and len(comparison_value) > 0:
+            comparison_value = [
+                sub_phone_number(rights_value) 
+                for rights_value in comparison_value
+            ]
 
             if rikolti_value == comparison_value:
                 return


### PR DESCRIPTION
🔀 _mapping_: `type->type` vocabulary additions: 
```
photographic_print: image
yearbook: text
school yearbook: text
scrapbook: text
```

🔀 _mapping_: `format->type` vocabulary additions:
```
still image: image
photographic postcard: image
```

PSPL (`oai.pspl`):
- 🔀 _mapping_: `type` split field on `;`

Islandora (`oai.islandora`):
- 🔀 _mapping_: `spatial`: collate spatial and coverage (same as base OAI), but then split on `;` 
- ✅ _validation_: `identifier`: identifier was previously order insensitive, but now it is also duplicate insensitive and counts differences of whitespace as duplicates, so `['islandora:52_0', 'filename: cartaz_030', 'islandora: 52_0']` contains a duplicate: `islandora:52_0` and `islandora: 52_0` - after de-duplication, it successfully content matches with `['filename: cartaz_030', 'islandora: 52_0']`
- ✅ _validation_: `rights`: rights field in solr contains an additional suffix: " For more information on copyright or permissions for this image, please contact San Jose State University Special Collections & Archives department. http://www.sjlibrary.org/research/special/special_coll/index.htm" for Collection 26575 - don't create validation errors for this difference.

Quartex (`oai.quartex`):
- 🐛  _bugfix_: `spatial`: filter spatial for None values after collating spatial and coverage, before trying to split None values on `;` (which throws an error)
- 🔀 _mapping_: `spatial`, `contributor` mapping - split on `;`
- ✅ _validation_: `creator`, `contributor` match rikolti values with an added trailing `.` that is not in solr
- ✅ _validation_: `description` match comparison values with an added trailing ` ` that is not in rikolti

Omeka (`oai.omeka`):
- 🔀 _mapping_: `rights_date`: map `dateCopyrighted` to `dateCopyrighted`; `solr_updater` copies `dateCopyrighted` into `rights_date`

Omeka CSA (previously ucsb_adc) (`oai.omeka.csa`):
- 🔀 _mapping_: `spatial`: split on `;`

Samvera:
- ✅ _validation_: ignore phone number discrepancies