### PR TITLE
Add default validations for addt'l fields not specified in UCLDC_map()

### DIFF
--- a/metadata_mapper/mappers/calisphere_solr/calisphere_solr_mapper.py
+++ b/metadata_mapper/mappers/calisphere_solr/calisphere_solr_mapper.py
@@ -49,19 +49,8 @@ class CalisphereSolrRecord(Record):
             "repository_data": self.source_metadata.get("repository_data", None),
             "repository_url": self.source_metadata.get("repository_url", None),
             "rights_uri": self.source_metadata.get("rights_uri", None),
-            "manifest": self.source_metadata.get("manifest", None),
-            "object_template": self.source_metadata.get("object_template", None),
-            "url_item": self.source_metadata.get("url_item", None),
-            "created": self.source_metadata.get("created", None),
-            "last_modified": self.source_metadata.get("last_modified", None),            
             "sort_date_start": self.source_metadata.get("sort_date_start", None),
             "sort_date_end": self.source_metadata.get("sort_date_end", None),
-            "campus_id": self.source_metadata.get("campus_id", None),
-            "collection_id": self.source_metadata.get("collection_id", None),
-            "repository_id": self.source_metadata.get("repository_id", None),
-            "item_count": self.source_metadata.get("item_count", None),
-            "reference_image_md5": self.source_metadata.get("reference_image_md5", None),
-            "reference_image_dimensions": self.source_metadata.get("reference_image_dimensions", None),
         }
 
     def map_calisphere_id(self):

--- a/metadata_mapper/validator/validator.py
+++ b/metadata_mapper/validator/validator.py
@@ -600,7 +600,6 @@ class Validator:
     def _ensure_is_list(value: Any) -> list[Any]:
         return value if isinstance(value, list) else [value]
 
-
 default_validatable_fields: list[dict[str, Any]] = [
     # Full fidelity fields
     # Full type and content matches required
@@ -665,6 +664,79 @@ default_validatable_fields: list[dict[str, Any]] = [
                         Validator.verify_type(str)
                         ]
     },
+    {
+        "field": "sort_title",
+        "validations": [
+                        Validator.required_field,
+                        Validator.content_match,
+                        Validator.verify_type(str)
+                        ]
+    },
+    {
+        "field": "collection_name",
+        "validations": [
+                        Validator.required_field,
+                        Validator.content_match,
+                        Validator.verify_type(str)
+                        ]
+    },
+    {
+        "field": "collection_data",
+        "validations": [
+                        Validator.required_field,
+                        Validator.content_match,
+                        Validator.verify_type(str)
+                        ]
+    },
+    {
+        "field": "collection_url",
+        "validations": [
+                        Validator.required_field,
+                        Validator.content_match,
+                        Validator.verify_type(str)
+                        ]
+    },
+    {
+        "field": "sort_collection_data",
+        "validations": [
+                        Validator.required_field,
+                        Validator.content_match,
+                        Validator.verify_type(str)
+                        ]
+    },
+    {
+        "field": "repository_name",
+        "validations": [
+                        Validator.required_field,
+                        Validator.content_match,
+                        Validator.verify_type(str)
+                        ]
+    },
+    {
+        "field": "repository_data",
+        "validations": [
+                        Validator.required_field,
+                        Validator.content_match,
+                        Validator.verify_type(str)
+                        ]
+    },
+    {
+        "field": "repository_url",
+        "validations": [
+                        Validator.required_field,
+                        Validator.content_match,
+                        Validator.verify_type(str)
+                        ]
+    },
+    {
+        "field": "url_item",
+        "validations": [
+                        Validator.required_field,
+                        Validator.content_match,
+                        Validator.verify_type(str)
+                        ]
+    },
+
     # Partial fidelity fields
     # Content match required; nulls okay
     {
@@ -781,7 +853,79 @@ default_validatable_fields: list[dict[str, Any]] = [
         "field": "transcription",
         "validations": [Validator.content_match],
         "level": ValidationLogLevel.WARNING
-    }
+    },
+    {
+        "field": "campus_name",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
+    {
+        "field": "campus_data",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
+    {
+        "field": "reference_image_md5",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
+    {
+        "field": "reference_image_dimensions",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
+    {
+        "field": "created",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
+    {
+        "field": "last_modified",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
+    {
+        "field": "sort_date_start",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
+    {
+        "field": "sort_date_end",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
+    {
+        "field": "item_count",
+        "validations": [Validator.content_match],
+       "level": ValidationLogLevel.WARNING
+    },
+    # analysis needed: are the following fields populated
+    # in solr for any records at all?
+    {
+        "field": "campus_id",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
+    {
+        "field": "collection_id",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
+    {
+        "field": "repository_id",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
+    {
+        "field": "manifest",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
+    {
+        "field": "object_template",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING
+    },
 ]
 
 Validator.validatable_fields = default_validatable_fields

--- a/metadata_mapper/validator/validator.py
+++ b/metadata_mapper/validator/validator.py
@@ -865,64 +865,12 @@ default_validatable_fields: list[dict[str, Any]] = [
         "level": ValidationLogLevel.WARNING
     },
     {
-        "field": "reference_image_md5",
-        "validations": [Validator.content_match],
-        "level": ValidationLogLevel.WARNING
-    },
-    {
-        "field": "reference_image_dimensions",
-        "validations": [Validator.content_match],
-        "level": ValidationLogLevel.WARNING
-    },
-    {
-        "field": "created",
-        "validations": [Validator.content_match],
-        "level": ValidationLogLevel.WARNING
-    },
-    {
-        "field": "last_modified",
-        "validations": [Validator.content_match],
-        "level": ValidationLogLevel.WARNING
-    },
-    {
         "field": "sort_date_start",
         "validations": [Validator.content_match],
         "level": ValidationLogLevel.WARNING
     },
     {
         "field": "sort_date_end",
-        "validations": [Validator.content_match],
-        "level": ValidationLogLevel.WARNING
-    },
-    {
-        "field": "item_count",
-        "validations": [Validator.content_match],
-       "level": ValidationLogLevel.WARNING
-    },
-    # analysis needed: are the following fields populated
-    # in solr for any records at all?
-    {
-        "field": "campus_id",
-        "validations": [Validator.content_match],
-        "level": ValidationLogLevel.WARNING
-    },
-    {
-        "field": "collection_id",
-        "validations": [Validator.content_match],
-        "level": ValidationLogLevel.WARNING
-    },
-    {
-        "field": "repository_id",
-        "validations": [Validator.content_match],
-        "level": ValidationLogLevel.WARNING
-    },
-    {
-        "field": "manifest",
-        "validations": [Validator.content_match],
-        "level": ValidationLogLevel.WARNING
-    },
-    {
-        "field": "object_template",
         "validations": [Validator.content_match],
         "level": ValidationLogLevel.WARNING
     },

--- a/metadata_mapper/validator/validator.py
+++ b/metadata_mapper/validator/validator.py
@@ -667,7 +667,6 @@ default_validatable_fields: list[dict[str, Any]] = [
     {
         "field": "sort_title",
         "validations": [
-                        Validator.required_field,
                         Validator.content_match,
                         Validator.verify_type(str)
                         ]
@@ -675,7 +674,6 @@ default_validatable_fields: list[dict[str, Any]] = [
     {
         "field": "collection_name",
         "validations": [
-                        Validator.required_field,
                         Validator.content_match,
                         Validator.verify_type(str)
                         ]
@@ -683,7 +681,6 @@ default_validatable_fields: list[dict[str, Any]] = [
     {
         "field": "collection_data",
         "validations": [
-                        Validator.required_field,
                         Validator.content_match,
                         Validator.verify_type(str)
                         ]
@@ -691,7 +688,6 @@ default_validatable_fields: list[dict[str, Any]] = [
     {
         "field": "collection_url",
         "validations": [
-                        Validator.required_field,
                         Validator.content_match,
                         Validator.verify_type(str)
                         ]
@@ -699,7 +695,6 @@ default_validatable_fields: list[dict[str, Any]] = [
     {
         "field": "sort_collection_data",
         "validations": [
-                        Validator.required_field,
                         Validator.content_match,
                         Validator.verify_type(str)
                         ]
@@ -707,7 +702,6 @@ default_validatable_fields: list[dict[str, Any]] = [
     {
         "field": "repository_name",
         "validations": [
-                        Validator.required_field,
                         Validator.content_match,
                         Validator.verify_type(str)
                         ]
@@ -715,7 +709,6 @@ default_validatable_fields: list[dict[str, Any]] = [
     {
         "field": "repository_data",
         "validations": [
-                        Validator.required_field,
                         Validator.content_match,
                         Validator.verify_type(str)
                         ]
@@ -723,7 +716,6 @@ default_validatable_fields: list[dict[str, Any]] = [
     {
         "field": "repository_url",
         "validations": [
-                        Validator.required_field,
                         Validator.content_match,
                         Validator.verify_type(str)
                         ]
@@ -731,7 +723,6 @@ default_validatable_fields: list[dict[str, Any]] = [
     {
         "field": "url_item",
         "validations": [
-                        Validator.required_field,
                         Validator.content_match,
                         Validator.verify_type(str)
                         ]

--- a/record_indexer/index_templates/record_index_config.json
+++ b/record_indexer/index_templates/record_index_config.json
@@ -57,22 +57,9 @@
                 "repository_data": {"type": "keyword"},
                 "repository_url": {"type": "keyword"},
                 "rights_uri": {"type": "keyword"},
-                "reference_image_md5": {"type": "keyword"},
-                "reference_image_dimensions": {"type": "keyword"},
-                "manifest": {"type": "keyword"},
-                "object_template": {"type": "keyword"},
-                "url_item": {"type": "keyword"},
 
-                "created": {"type": "date", "fields": {"raw": {"type": "keyword"}}},
-                "last_modified": {"type": "date", "fields": {"raw": {"type": "keyword"}}},
                 "sort_date_start": {"type": "date"},
                 "sort_date_end": {"type": "date"},
-
-                "campus_id": {"type": "integer"},
-                "collection_id": {"type": "integer"},
-                "repository_id": {"type": "integer"},
-                "item_count": {"type": "integer"},
-
 
                 "media": {
                     "properties": {

--- a/record_indexer/index_templates/record_index_config.json
+++ b/record_indexer/index_templates/record_index_config.json
@@ -57,6 +57,7 @@
                 "repository_data": {"type": "keyword"},
                 "repository_url": {"type": "keyword"},
                 "rights_uri": {"type": "keyword"},
+                "url_item": {"type": "keyword"},
 
                 "sort_date_start": {"type": "date"},
                 "sort_date_end": {"type": "date"},


### PR DESCRIPTION
I don't think any of these fields need custom validators since we're comparing the content to what's currently in Solr, but if you think it's a good idea then let me know. Some fields that are funky (they have `::` as a separator): campus_data, collection_data, repository_data.