### PR TITLE
S3 pagination

### DIFF
--- a/utils/storage.py
+++ b/utils/storage.py
@@ -98,20 +98,23 @@ def list_s3_pages(data: DataStorage, recursive: bool=True, **kwargs) -> list:
     List all objects in s3_bucket with prefix s3_prefix
     """
     s3 = boto3.client('s3', **kwargs)
-    s3_objects = s3.list_objects_v2(
+    paginator = s3.get_paginator('list_objects_v2')
+    pages = paginator.paginate(
         Bucket=data.bucket, 
         Prefix=data.path.lstrip('/')
     )
-    # TODO: check resp['IsTruncated'] and use ContinuationToken if needed
 
-    keys = [f"s3://{data.bucket}/{obj['Key']}" for obj in s3_objects['Contents']]
-    prefix = f"s3://{data.bucket}/{data.path}"
+    keys = []
+    for page in pages:
+        keys += [f"s3://{data.bucket}/{obj['Key']}" for obj in page['Contents']]
 
     if not recursive:
         # prune deeper branches
+        prefix = f"s3://{data.bucket}/{data.path}"
         leaf_regex = re.escape(prefix) + r"^\/?[\w!'_.*()-]+\/?$"
         keys = [key for key in keys if re.match(leaf_regex, key)]
 
+    print(f"len(keys): {len(keys)}")
     return keys
 
 

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -105,7 +105,7 @@ def list_s3_pages(data: DataStorage, recursive: bool=True, **kwargs) -> list:
     )
 
     keys = []
-    for page in pages:
+    for obj_list in page_iterator:
         keys += [f"s3://{data.bucket}/{obj['Key']}" for obj in page['Contents']]
 
     if not recursive:

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -106,7 +106,7 @@ def list_s3_pages(data: DataStorage, recursive: bool=True, **kwargs) -> list:
 
     keys = []
     for obj_list in page_iterator:
-        keys += [f"s3://{data.bucket}/{obj['Key']}" for obj in page['Contents']]
+        keys += [f"s3://{data.bucket}/{obj['Key']}" for obj in obj_list['Contents']]
 
     if not recursive:
         # prune deeper branches

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -114,7 +114,6 @@ def list_s3_pages(data: DataStorage, recursive: bool=True, **kwargs) -> list:
         leaf_regex = re.escape(prefix) + r"^\/?[\w!'_.*()-]+\/?$"
         keys = [key for key in keys if re.match(leaf_regex, key)]
 
-    print(f"len(keys): {len(keys)}")
     return keys
 
 

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -99,7 +99,7 @@ def list_s3_pages(data: DataStorage, recursive: bool=True, **kwargs) -> list:
     """
     s3 = boto3.client('s3', **kwargs)
     paginator = s3.get_paginator('list_objects_v2')
-    pages = paginator.paginate(
+    page_iterator = paginator.paginate(
         Bucket=data.bucket, 
         Prefix=data.path.lstrip('/')
     )

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -31,7 +31,9 @@ def get_version(collection_id: Union[int, str], uri: str) -> str:
     uri_parts = uri.lstrip('/').split('/')
     if str(collection_id) not in uri_parts or len(uri_parts) < 2:
         raise Exception(f"Not a valid version path: {uri}, {uri_parts}")
-    rikolti_data_root, relative_path = uri.split(f"{collection_id}/")
+    if not uri.startswith("/"):
+        uri = f"/{uri}"
+    rikolti_data_root, relative_path = uri.split(f"/{collection_id}/")
     path_list = relative_path.split('/')
     if 'data' in path_list:
         path_list = path_list[:path_list.index('data')]

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -25,6 +25,7 @@ def get_version(collection_id: Union[int, str], uri: str) -> str:
     keyword.
 
     Returns a version path.
+    Test cases we've encountered: "8/vernacular_metadata_2024-01-31T00:39:58/data/986", "8/vernacular_metadata_v1/data/8"
     """
     collection_id = str(collection_id)
     uri_parts = uri.strip('/').split('/')

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -27,17 +27,12 @@ def get_version(collection_id: Union[int, str], uri: str) -> str:
     Returns a version path.
     """
     collection_id = str(collection_id)
-    uri = uri.rstrip('/')
-    uri_parts = uri.lstrip('/').split('/')
+    uri_parts = uri.strip('/').split('/')
     if str(collection_id) not in uri_parts or len(uri_parts) < 2:
         raise Exception(f"Not a valid version path: {uri}, {uri_parts}")
-    if not uri.startswith("/"):
-        uri = f"/{uri}"
-    rikolti_data_root, relative_path = uri.split(f"/{collection_id}/")
-    path_list = relative_path.split('/')
+    path_list = uri_parts[uri_parts.index(collection_id):]
     if 'data' in path_list:
         path_list = path_list[:path_list.index('data')]
-    path_list.insert(0, str(collection_id))
     version = "/".join(path_list)
     return version
 


### PR DESCRIPTION
This PR adds pagination to the `s3.list_objects_v2()` in `utils.storage.list_s3_pages()` so that we now get results over 1000.

It also fixes a bug that I ran into in `utils.versions.get_version()` where splitting on `f"{collection_id}/` would sometimes return a list of more than 2 elements, e.g. for the following uri:

```8/vernacular_metadata_2024-01-31T00:39:58/data/986```