### PR TITLE
Handle empty md pages

### DIFF
--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -70,7 +70,8 @@ def merge_children(version):
 
 @task()
 def get_mapped_page_filenames_task(mapped_pages):
-    return [mapped['mapped_page_path'] for mapped in mapped_pages]
+    return [mapped['mapped_page_path'] for mapped in mapped_pages
+        if mapped['mapped_page_path']]
 
 
 @dag(

--- a/dags/shared_tasks.py
+++ b/dags/shared_tasks.py
@@ -152,7 +152,7 @@ def map_page_task(vernacular_page: str, collection: dict, mapped_data_version: s
         status: success
         num_records_mapped: int
         page_exceptions: TODO
-        mapped_page_path: str, ex: 
+        mapped_page_path|None: str, ex:
             3433/vernacular_metadata_2023-01-01T00:00:00/mapped_metadata_2023-01-01T00:00:00/1.jsonl
     """
     collection_id = collection.get('id')
@@ -170,7 +170,7 @@ def get_mapping_status_task(collection: dict, mapped_pages: list):
         status: success
         num_records_mapped: int
         page_exceptions: TODO
-        mapped_page_path: str, ex: 
+        mapped_page_path: str|None, ex:
             3433/vernacular_metadata_2023-01-01T00:00:00/mapped_metadata_2023-01-01T00:00:00/1.jsonl
     returns a dict with the following keys:
         mapped_page_paths: ex: [

--- a/dags/shared_tasks.py
+++ b/dags/shared_tasks.py
@@ -233,8 +233,9 @@ def validate_collection_task(collection_id: int, mapped_metadata_pages: dict) ->
 
 @task()
 def create_with_content_urls_version_task(collection: dict, mapped_pages: list[dict]):
-    mapped_version = get_version(
-        collection['id'], mapped_pages[0]['mapped_page_path'])
+    mapped_page_path = [page['mapped_page_path'] for page in mapped_pages
+        if page['mapped_page_path']][0]
+    mapped_version = get_version(collection['id'], mapped_page_path)
     return create_with_content_urls_version(mapped_version)
 
 

--- a/metadata_fetcher/fetchers/Fetcher.py
+++ b/metadata_fetcher/fetchers/Fetcher.py
@@ -60,15 +60,20 @@ class Fetcher(object):
                 f"[{self.collection_id}]: unable to fetch page {page}")
 
         record_count = self.check_page(response)
+        if not record_count:
+            logger.warning(
+                f"[{self.collection_id}]: no records found "
+                f"on page {self.write_page}"
+            )
+
         filepath = None
-        if record_count:
-            content = self.aggregate_vernacular_content(response)
-            try:
-                filepath = put_vernacular_page(
-                    content, self.write_page, self.vernacular_version)
-            except Exception as e:
-                print(f"Metadata Fetcher: {e}")
-                raise(e)
+        content = self.aggregate_vernacular_content(response)
+        try:
+            filepath = put_vernacular_page(
+                content, self.write_page, self.vernacular_version)
+        except Exception as e:
+            print(f"Metadata Fetcher: {e}")
+            raise(e)
 
         self.increment(response)
 

--- a/metadata_mapper/lambda_function.py
+++ b/metadata_mapper/lambda_function.py
@@ -116,52 +116,52 @@ def map_page(
             'page_exceptions': {},
             'mapped_page_path': None,
         }
-    else:
-        source_metadata_records = run_enrichments(
-            source_metadata_records, collection, 'rikolti__pre_mapping', page_filename)
 
-        for record in source_metadata_records:
-            record.to_UCLDC()
-        mapped_records = source_metadata_records
+    source_metadata_records = run_enrichments(
+        source_metadata_records, collection, 'rikolti__pre_mapping', page_filename)
 
-        mapped_records = run_enrichments(
-            mapped_records, collection, 'rikolti__enrichments', page_filename)
+    for record in source_metadata_records:
+        record.to_UCLDC()
+    mapped_records = source_metadata_records
 
-        # TODO: analyze and simplify this straight port of the
-        # solr updater module into the Rikolti framework
-        if collection.get('rikolti_mapper_type') != 'calisphere_solr.calisphere_solr':
-            mapped_records = [record.solr_updater() for record in mapped_records]
-        mapped_records = [record.remove_none_values() for record in mapped_records]
+    mapped_records = run_enrichments(
+        mapped_records, collection, 'rikolti__enrichments', page_filename)
 
-        group_page_exceptions = {}
-        page_exceptions = {
-            rec.legacy_couch_db_id: rec.enrichment_report
-            for rec in mapped_records if rec.enrichment_report
-        }
-        if page_exceptions:
-            # Group like lists of enrichment chain errors
-            for couch_id, reports in page_exceptions.items():
-                report = " | ".join(reports)
-                group_page_exceptions.setdefault(report, []).append(couch_id)
+    # TODO: analyze and simplify this straight port of the
+    # solr updater module into the Rikolti framework
+    if collection.get('rikolti_mapper_type') != 'calisphere_solr.calisphere_solr':
+        mapped_records = [record.solr_updater() for record in mapped_records]
+    mapped_records = [record.remove_none_values() for record in mapped_records]
 
-        # some enrichments had previously happened at ingest into Solr
-        # TODO: these are just two, investigate further
-        # mapped_records = [record.add_sort_title() for record in mapped_records]
-        # mapped_records = [record.map_registry_data(collection)
-        #                   for record in mapped_records]
+    group_page_exceptions = {}
+    page_exceptions = {
+        rec.legacy_couch_db_id: rec.enrichment_report
+        for rec in mapped_records if rec.enrichment_report
+    }
+    if page_exceptions:
+        # Group like lists of enrichment chain errors
+        for couch_id, reports in page_exceptions.items():
+            report = " | ".join(reports)
+            group_page_exceptions.setdefault(report, []).append(couch_id)
 
-        mapped_metadata = [record.to_dict() for record in mapped_records]
+    # some enrichments had previously happened at ingest into Solr
+    # TODO: these are just two, investigate further
+    # mapped_records = [record.add_sort_title() for record in mapped_records]
+    # mapped_records = [record.map_registry_data(collection)
+    #                   for record in mapped_records]
 
-        mapped_page_path = put_mapped_page(
-            json.dumps(mapped_metadata, ensure_ascii=False),
-            page_filename, mapped_data_version)
+    mapped_metadata = [record.to_dict() for record in mapped_records]
 
-        return {
-            'status': 'success',
-            'num_records_mapped': len(mapped_metadata),
-            'page_exceptions': group_page_exceptions,
-            'mapped_page_path': mapped_page_path,
-        }
+    mapped_page_path = put_mapped_page(
+        json.dumps(mapped_metadata, ensure_ascii=False),
+        page_filename, mapped_data_version)
+
+    return {
+        'status': 'success',
+        'num_records_mapped': len(mapped_metadata),
+        'page_exceptions': group_page_exceptions,
+        'mapped_page_path': mapped_page_path,
+    }
 
 
 if __name__ == "__main__":

--- a/metadata_mapper/lambda_function.py
+++ b/metadata_mapper/lambda_function.py
@@ -90,7 +90,7 @@ def map_page(
         status: success
         num_records_mapped: int
         page_exceptions: TODO
-        mapped_page_path: str, ex:
+        mapped_page_path: str|None, ex:
             3433/vernacular_metadata_v1/mapped_metadata_v1/data/1.jsonl
     """
     if isinstance(collection, str):
@@ -106,12 +106,16 @@ def map_page(
     source_metadata_records = source_vernacular.parse(api_resp)
 
     if not source_metadata_records:
-        mapped_metadata = []
-        group_page_exceptions = {}
         logging.warning(
             f"No source vernacular records found for {collection_id} "
             f"page {vernacular_page_path}."
             )
+        return {
+            'status': 'success',
+            'num_records_mapped': 0,
+            'page_exceptions': {},
+            'mapped_page_path': None,
+        }
     else:
         source_metadata_records = run_enrichments(
             source_metadata_records, collection, 'rikolti__pre_mapping', page_filename)
@@ -148,16 +152,16 @@ def map_page(
 
         mapped_metadata = [record.to_dict() for record in mapped_records]
 
-    mapped_page_path = put_mapped_page(
-        json.dumps(mapped_metadata, ensure_ascii=False),
-        page_filename, mapped_data_version)
+        mapped_page_path = put_mapped_page(
+            json.dumps(mapped_metadata, ensure_ascii=False),
+            page_filename, mapped_data_version)
 
-    return {
-        'status': 'success',
-        'num_records_mapped': len(mapped_metadata),
-        'page_exceptions': group_page_exceptions,
-        'mapped_page_path': mapped_page_path,
-    }
+        return {
+            'status': 'success',
+            'num_records_mapped': len(mapped_metadata),
+            'page_exceptions': group_page_exceptions,
+            'mapped_page_path': mapped_page_path,
+        }
 
 
 if __name__ == "__main__":

--- a/metadata_mapper/lambda_shepherd.py
+++ b/metadata_mapper/lambda_shepherd.py
@@ -46,7 +46,7 @@ def get_mapping_status(collection, mapped_pages):
         status: success
         num_records_mapped: int
         page_exceptions: TODO
-        mapped_page_path: str, ex:
+        mapped_page_path: str|None, ex:
             3433/vernacular_metadata_v1/mapped_metadata_v1/data/1.jsonl
     returns a dict, one of the keys is mapped_page_paths:
         mapped_page_paths: ex: [
@@ -73,7 +73,8 @@ def get_mapping_status(collection, mapped_pages):
         'count': count,
         'page_count': page_count,
         'group_exceptions': group_exceptions,
-        'mapped_page_paths': [page['mapped_page_path'] for page in mapped_pages],
+        'mapped_page_paths': [page['mapped_page_path'] for page in mapped_pages
+            if page['mapped_page_path']],
     }
 
 def map_collection(collection_id, vernacular_version=None, validate=False):

--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -143,8 +143,9 @@ class Record(ABC, object):
         try:
             return func(**kwargs)
         except Exception as e:
-            print(f"ENRICHMENT ERROR: {str(kwargs)}")
-            raise e
+            raise Exception(f"ENRICHMENT ERROR for enrichment: `{enrichment_function_name}` "
+                f"with kwargs: `{str(kwargs)}` "
+                )
 
     def select_id(self, prop: list[str]):
         """
@@ -918,8 +919,10 @@ class Record(ABC, object):
             return None
 
         prop = prop[0].split('/')[-1]  # remove sourceResource
-        value = self.mapped_data[prop]
-        self.mapped_data[prop] = recursive_substring_replace(value, old[0], new)
+        value = self.mapped_data.get(prop)
+        if value:
+            self.mapped_data[prop] = recursive_substring_replace(
+                value, old[0], new)
         return self
 
     def filter_fields(self, **_):

--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -142,7 +142,7 @@ class Record(ABC, object):
         func: Callable = getattr(self, enrichment_function_name)
         try:
             return func(**kwargs)
-        except Exception as e:
+        except Exception:
             raise Exception(f"ENRICHMENT ERROR for enrichment: `{enrichment_function_name}` "
                 f"with kwargs: `{str(kwargs)}` "
                 )

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -168,10 +168,11 @@ def validate_page(collection_id: int, page_path: str,
     collection = get_mapped_page_content(page_path)
 
     if len(collection) == 0:
-        raise ValueError(
-            f"No mapped metadata found for {collection_id} "
-            f"page {page_path}. Aborting."
+        print(
+            f"WARNING: No mapped metadata found for {collection_id} "
+            f"page {page_path}."
         )
+        return [],[]
 
     mapped_metadata = validator.generate_keys(
                         collection,


### PR DESCRIPTION
This PR updates the codebase to allow for vernacular pages that do not contain any metadata records. In this case:
- the fetcher issues a warning and writes the API reponse to storage. I figure that storing the page will be helpful for troubleshooting and verifying whether or not the the empty page is harmless
- the mapper issues a warning and mapping/enrichment is skipped
- a mapped_metadata page is not written to storage and `mapped_page_path` in the return dict is set to `None`

The code is also updated in several places to handle a None value for `mapped_page_path`, where before the code was always expecting a string value.

Finally, it fixes a of bug in `mapper.py` where exceptions in enrichments were not getting raised, which was obscuring a problem in `replace_substring()`.