### PR TITLE
Rikolti event stream updates

### DIFF
--- a/dags/shared_tasks/shared.py
+++ b/dags/shared_tasks/shared.py
@@ -22,19 +22,23 @@ def send_event_to_sns(context: dict, task_message: dict):
     Returns:
         None
     """
-    task_instance = context['task_instance']
+    dag_run = context['dag_run']
     log_message = {
-        'dag_id': task_instance.dag_id, 
-        'dag_run_id': task_instance.dag_run.run_id,
-        'logical_date': task_instance.dag_run.logical_date.isoformat(),
-        'task_id': task_instance.task_id,
-        'try_number': task_instance.try_number,
-        'map_index': task_instance.map_index,
-        'dag_run_conf': task_instance.dag_run.conf,
-        # TODO: this doesn't actually work to get the task parameters
-        # 'task_params': task_instance.xcom_pull(task_ids=task_instance.task_id),
-        'rikolti_message': task_message
+        'dag_id': dag_run.dag_id,
+        'dag_run_id': dag_run.run_id,
+        'logical_date': dag_run.logical_date.isoformat(),
+        'dag_run_conf': dag_run.conf,
     }
+    task_instance = context.get('task_instance')
+    if task_instance:
+        log_message.update({
+            'task_id': task_instance.task_id,
+            'try_number': task_instance.try_number,
+            'map_index': task_instance.map_index,
+            # TODO: this doesn't actually work to get the task parameters
+            # 'task_params': task_instance.xcom_pull(task_ids=task_instance.task_id),
+        })
+    log_message['rikolti_message'] = task_message
     message_body = json.dumps(log_message)
 
     sns = boto3.client('sns')

--- a/dags/shared_tasks/shared.py
+++ b/dags/shared_tasks/shared.py
@@ -42,9 +42,9 @@ def send_event_to_sns(context: dict, task_message: dict):
     log_message['rikolti_message'] = task_message
     message_body = json.dumps(log_message)
 
-    sns = boto3.client('sns')
-    topic_arn = os.environ.get('RIKOLTI_EVENTS_SNS_TOPIC', '')
     try:
+        sns = boto3.client('sns')
+        topic_arn = os.environ.get('RIKOLTI_EVENTS_SNS_TOPIC', '')
         response = sns.publish(
             TopicArn=topic_arn,
             Message=message_body

--- a/dags/shared_tasks/shared.py
+++ b/dags/shared_tasks/shared.py
@@ -1,6 +1,7 @@
 import boto3
 import os
 import json
+import traceback
 
 import requests
 
@@ -54,9 +55,16 @@ def send_event_to_sns(context: dict, task_message: dict):
 
 
 def notify_rikolti_failure(context):
+    exception = context['exception']
+    tb_as_str_list = traceback.format_exception(
+        type(exception), exception, exception.__traceback__)
+    exc_as_str_list = traceback.format_exception_only(
+        type(exception), exception)
+
     rikolti_message = {
         'error': True,
-        'exception': context['exception']
+        'exception': '\n'.join(exc_as_str_list),
+        'traceback': ''.join(tb_as_str_list)
     }
     send_event_to_sns(context, rikolti_message)
 
@@ -70,7 +78,7 @@ def notify_dag_failure(context):
     rikolti_message = {
         'dag_complete': False,
         'error': True,
-        'exception': context['exception']
+        'reason': context.get('reason', 'Unknown reason')
     }
     send_event_to_sns(context, rikolti_message)
 

--- a/dags/shared_tasks/shared.py
+++ b/dags/shared_tasks/shared.py
@@ -23,18 +23,21 @@ def send_event_to_sns(context: dict, task_message: dict):
     Returns:
         None
     """
+    base_url = context['conf'].get('webserver', 'BASE_URL')
     dag_run = context['dag_run']
     log_message = {
+        'version': os.environ.get('RIKOLTI_EVENT_VERSION', '1.0'),
         'dag_id': dag_run.dag_id,
         'dag_run_id': dag_run.run_id,
         'logical_date': dag_run.logical_date.isoformat(),
         'dag_run_conf': dag_run.conf,
+        'host': base_url
     }
     task_instance = context.get('task_instance')
     if task_instance:
         log_message.update({
             'task_id': task_instance.task_id,
-            'try_number': task_instance.try_number,
+            'try_number': task_instance.prev_attempted_tries,
             'map_index': task_instance.map_index,
             # TODO: this doesn't actually work to get the task parameters
             # 'task_params': task_instance.xcom_pull(task_ids=task_instance.task_id),


### PR DESCRIPTION
- Resolves issue where dag-level callbacks were failing (resulting in never sending a `dag_complete` message to the registry.
- Resolves issue where failure callbacks were failing (resulting in never sending an `error` message to the registry.
- Resolves issue where send_event_to_sns fails noisily if permissions to create an sns client are unavailable.
- Resolves issue where try_number was not consistently getting reported, turns out `task_instance.try_number` is *not* the current try number, but is actually the try_number the next time the task will run. It's complicated. `task_instance.pre_attempted_tries` is stable. 
- Adds 'version' and 'host' to the the event message, to support different airflow hosts, and version to allow the Registry's `rikolti_status` command to switch on different version numbers as we build out this event structure going forward. 