### PR TITLE
Add thumbnail dimensions; add pillow req to content_harvester img

### DIFF
--- a/content_harvester/requirements.txt
+++ b/content_harvester/requirements.txt
@@ -1,3 +1,4 @@
 requests
 boto3
 python-dotenv
+pillow


### PR DESCRIPTION
Doesn't add `reference_image_dimensions` to the Open Search index, but does add `dimensions` into the `thumbnail` datastructure, which I believe goes directly into Open Search? 