### PR TITLE
Bugfixes

### DIFF
--- a/metadata_mapper/lambda_shepherd.py
+++ b/metadata_mapper/lambda_shepherd.py
@@ -94,8 +94,8 @@ def get_mapping_status(
 
 def print_map_status(collection, map_result: MappedCollectionStatus):
     collection_id = collection['collection_id']
-    pre_mapping = collection.get('rikolti__pre_mapping')
-    enrichments = collection.get('rikolti__enrichments')
+    pre_mapping = collection.get('rikolti__pre_mapping', [])
+    enrichments = collection.get('rikolti__enrichments', [])
 
     if len(pre_mapping) > 0:
         print(

--- a/metadata_mapper/mappers/calisphere_solr/calisphere_solr_mapper.py
+++ b/metadata_mapper/mappers/calisphere_solr/calisphere_solr_mapper.py
@@ -17,6 +17,7 @@ class CalisphereSolrRecord(Record):
             "coverage": self.source_metadata.get("coverage", None),
             "creator": self.source_metadata.get("creator", None),
             "date": self.source_metadata.get("date", None),
+            "facet_decade": self.source_metadata.get('facet_decade', None),
             "extent": self.source_metadata.get("extent", None),
             "format": self.source_metadata.get("format", None),
             "genre": self.source_metadata.get("genre", None),

--- a/metadata_mapper/validator/validator.py
+++ b/metadata_mapper/validator/validator.py
@@ -796,6 +796,11 @@ default_validatable_fields: list[dict[str, Any]] = [
         "validation_mode": ValidationMode.ORDER_INSENSITIVE_IF_LIST
     },
     {
+        "field": "facet_decade",
+        "validations": [Validator.content_match],
+        "level": ValidationLogLevel.WARNING,
+    },
+    {
         "field": "description",
         "validations": [Validator.content_match],
         "level": ValidationLogLevel.WARNING

--- a/record_indexer/index_templates/record_index_config.py
+++ b/record_indexer/index_templates/record_index_config.py
@@ -50,16 +50,13 @@ RECORD_INDEX_CONFIG = {
                 "campus_name": {"type": "keyword"},
                 "campus_data": {"type": "keyword"},
                 "campus_url": {"type": "keyword"},
-                "campus_id": {"type": "alias", "path": "campus_url"},
                 "collection_name": {"type": "keyword"},
                 "collection_data": {"type": "keyword"},
                 "collection_url": {"type": "keyword"},
-                "collection_id": {"type": "alias", "path": "collection_url"},
                 "sort_collection_data": {"type": "keyword"},
                 "repository_name": {"type": "keyword"},
                 "repository_data": {"type": "keyword"},
                 "repository_url": {"type": "keyword"},
-                "repository_id": {"type": "alias", "path": "repository_url"},
                 "rights_uri": {"type": "keyword"},
                 "url_item": {"type": "keyword"},
                 "fetcher_type": {"type": "keyword"},
@@ -71,7 +68,8 @@ RECORD_INDEX_CONFIG = {
                 "media": {
                     "properties": {
                         "media_filepath": {"type": "keyword"},
-                        "mimetype": {"type": "keyword"}
+                        "mimetype": {"type": "keyword"},
+                        "path": {"type": "keyword"}
                     }
                 },
                 "media_source": {
@@ -85,7 +83,9 @@ RECORD_INDEX_CONFIG = {
                 "thumbnail": {
                     "properties": {
                         "mimetype": {"type": "keyword"},
-                        "thumbnail_filepath": {"type": "keyword"}
+                        "thumbnail_filepath": {"type": "keyword"},
+                        "path": {"type": "keyword"},
+                        "dimensions": {"type": "keyword"}
                     }
                 },
                 "thumbnail_source": {

--- a/record_indexer/index_templates/record_index_config.py
+++ b/record_indexer/index_templates/record_index_config.py
@@ -40,6 +40,7 @@ RECORD_INDEX_CONFIG = {
                 "type": {"type": "text", "fields": {"raw": {"type": "keyword"}}},
 
                 "sort_title": {"type": "text", "analyzer": "keyword_lowercase_trim"},
+                "facet_decade": {"type": "text", "fields": {"raw": {"type": "keyword"}}},
 
                 "description": {"type": "text"},
                 "provenance": {"type": "text"},


### PR DESCRIPTION
closes https://github.com/ucldc/rikolti/issues/784 - we were seeing date errors because without an index template, OpenSearch was sometimes inferring the date field to be of type date 

closes https://github.com/ucldc/rikolti/issues/811 - ETL collections don't have any enrichments

closes #813 - adds facet_decade to the OpenSearch schema + the validator schema + the calisphere_solr_mapper
