### PR TITLE
Bugfixes

### DIFF
--- a/metadata_mapper/lambda_shepherd.py
+++ b/metadata_mapper/lambda_shepherd.py
@@ -68,6 +68,7 @@ def get_mapping_status(
         for exception, couch_ids in page_exceptions.items():
             group_exceptions.setdefault(exception, []).extend(couch_ids)
 
+    version = None
     for mapped_page_status in mapped_page_statuses:
         if mapped_page_status.mapped_page_path:
             version = get_version(
@@ -75,6 +76,11 @@ def get_mapping_status(
                 mapped_page_status.mapped_page_path
             )
             break
+
+    if not version:
+        raise ValueError(
+            f"Could not determine version from {mapped_page_statuses}"
+        )
 
     return MappedCollectionStatus(
         'success',

--- a/record_indexer/add_page_to_index.py
+++ b/record_indexer/add_page_to_index.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 
 from pprint import pprint
 
@@ -80,15 +81,13 @@ def add_page(version_page: str, index: str):
         records = get_with_content_urls_page_content(version_page)
 
     expected_fields = get_expected_fields()
-    flag_removed_fields = {}
+    removed_fields_report = defaultdict(list)
     for record in records:
         removed_fields = remove_unexpected_fields(record, expected_fields)
         calisphere_id = record.get("calisphere-id", None)
         for field in removed_fields:
-            if field in flag_removed_fields:
-                flag_removed_fields[field].append(calisphere_id)
-            else:
-                flag_removed_fields[field] = [calisphere_id]
+            removed_fields_report[field].append(calisphere_id)
+
 
     bulk_add(records, index)
 
@@ -96,7 +95,7 @@ def add_page(version_page: str, index: str):
         f"added {len(records)} records to index `{index}` from "
         f"page `{version_page}`"
     )
-    for field, calisphere_ids in flag_removed_fields.items():
+    for field, calisphere_ids in removed_fields_report.items():
         if len(calisphere_ids) != len(records):
             print(
                 f"    {len(calisphere_ids)} items had {field} "

--- a/record_indexer/add_page_to_index.py
+++ b/record_indexer/add_page_to_index.py
@@ -64,6 +64,15 @@ def remove_unexpected_fields(record: dict, expected_fields: list):
             removed_fields.append(field)
             record.pop(field)
 
+    # TODO: not sure if we want to qualify field names with the parent id
+    parent_id = record.get('calisphere-id')
+    for child in record.get('children', []):
+        removed_fields_from_child = remove_unexpected_fields(
+            child, expected_fields)
+        removed_fields += [
+            f"{parent_id}[{field}]" for field in removed_fields_from_child
+        ]
+
     return removed_fields
 
 

--- a/record_indexer/index_templates/record_index_config.py
+++ b/record_indexer/index_templates/record_index_config.py
@@ -70,7 +70,8 @@ RECORD_INDEX_CONFIG = {
                     "properties": {
                         "media_filepath": {"type": "keyword"},
                         "mimetype": {"type": "keyword"},
-                        "path": {"type": "keyword"}
+                        "path": {"type": "keyword"},
+                        "format": {"type": "keyword"},
                     }
                 },
                 "media_source": {


### PR DESCRIPTION
Closes #829 
- Makes the sieve to filter out unwanted fields at indexing time recursive - traversing child documents
- Adds media.format to the record index config
- Raises an exception if Get Mapping Status cannot retrieve a mapped_version (this will happen when no pages were fetched and so no pages were mapped - the fetcher passes, but prints out a statement saying "no pages fetched", the mapping job passes as well but prints out a statement saying "no pages mapped") It does seem like this should fail earlier in the process, but I'm not quite sure where (see #826)