### PR TITLE
Add `url_item`, `fetcher_type` and `mapper_type` to calisphere_solr mapper

### DIFF
--- a/metadata_mapper/mappers/calisphere_solr/calisphere_solr_mapper.py
+++ b/metadata_mapper/mappers/calisphere_solr/calisphere_solr_mapper.py
@@ -10,6 +10,9 @@ class CalisphereSolrRecord(Record):
         return {
             "calisphere-id": self.map_calisphere_id(),
             "is_shown_at": self.source_metadata.get("url_item"),
+            "url_item": self.source_metadata.get("url_item"),
+            "fetcher_type": ["calisphere_solr"],
+            "mapper_type": ["calisphere_solr.calisphere_solr"],
             "thumbnail_source": self.map_thumbnail_source(),
             "title": self.source_metadata.get("title"),
             "alternative_title": self.source_metadata.get("alternative_title", None),


### PR DESCRIPTION
For all other mapper types, these 3 fields are mapped in `solr_updater`. However, we don't run `solr_updater` for ETL collections, so these mappings needed to be added to the calisphere_solr mapper itself.