### PR TITLE
Capture PIL errors and print calisphere-id

### DIFF
--- a/content_harvester/by_record.py
+++ b/content_harvester/by_record.py
@@ -3,6 +3,7 @@ import os
 from typing import Optional
 
 from PIL import Image
+from PIL import UnidentifiedImageError
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
@@ -108,7 +109,18 @@ def harvest_record_content(
             content_s3_filepath = upload_content(
                 thumbnail.tmp_filepath, f"thumbnails/{collection_id}/{downloaded_md5}"
             )
-            dimensions = Image.open(thumbnail.tmp_filepath).size
+            try:
+                dimensions = Image.open(thumbnail.tmp_filepath).size
+            except UnidentifiedImageError as e:
+                raise Exception(
+                    f"PIL.UnidentifiedImageError for calisphere-id "
+                    f"{record['calisphere-id']}: {e}"
+                )
+            except Image.DecompressionBombError as e:
+                raise Exception(
+                    f"PIL.Image.DecompressionBombError for calisphere-id "
+                    f"{record['calisphere-id']}: {e}"
+                )
         elif downloaded_md5 and thumbnail.src_mime_type == 'application/pdf':
             derivative_filepath = derivatives.pdf_to_thumb(thumbnail.tmp_filepath)
             if derivative_filepath:

--- a/content_harvester/by_record.py
+++ b/content_harvester/by_record.py
@@ -109,18 +109,8 @@ def harvest_record_content(
             content_s3_filepath = upload_content(
                 thumbnail.tmp_filepath, f"thumbnails/{collection_id}/{downloaded_md5}"
             )
-            try:
-                dimensions = Image.open(thumbnail.tmp_filepath).size
-            except UnidentifiedImageError as e:
-                raise Exception(
-                    f"PIL.UnidentifiedImageError for calisphere-id "
-                    f"{record['calisphere-id']}: {e}"
-                )
-            except Image.DecompressionBombError as e:
-                raise Exception(
-                    f"PIL.Image.DecompressionBombError for calisphere-id "
-                    f"{record['calisphere-id']}: {e}"
-                )
+            dimensions = get_dimensions(thumbnail.tmp_filepath, record['calisphere-id'])
+
         elif downloaded_md5 and thumbnail.src_mime_type == 'application/pdf':
             derivative_filepath = derivatives.pdf_to_thumb(thumbnail.tmp_filepath)
             if derivative_filepath:
@@ -129,7 +119,7 @@ def harvest_record_content(
                 content_s3_filepath = upload_content(
                     derivative_filepath, f"thumbnails/{collection_id}/{md5}"
                 )
-                dimensions = Image.open(derivative_filepath).size
+                dimensions = get_dimensions(derivative_filepath, record['calisphere-id'])
         elif downloaded_md5 and thumbnail.src_mime_type == 'video/mp4':
             derivative_filepath = derivatives.video_to_thumb(thumbnail.tmp_filepath)
             if derivative_filepath:
@@ -138,7 +128,7 @@ def harvest_record_content(
                 content_s3_filepath = upload_content(
                     derivative_filepath, f"thumbnails/{collection_id}/{md5}"
                 )
-                dimensions = Image.open(derivative_filepath).size
+                dimensions = get_dimensions(derivative_filepath, record['calisphere-id'])
 
         if content_s3_filepath:
             record['thumbnail'] = {
@@ -155,6 +145,19 @@ def harvest_record_content(
 
     return record
 
+def get_dimensions(filepath: str, calisphere_id: str) -> str:
+    try:
+        return Image.open(filepath).size
+    except UnidentifiedImageError as e:
+        raise Exception(
+            f"PIL.UnidentifiedImageError for calisphere-id "
+            f"{calisphere_id}: {e}"
+        )
+    except Image.DecompressionBombError as e:
+        raise Exception(
+            f"PIL.Image.DecompressionBombError for calisphere-id "
+            f"{calisphere_id}: {e}"
+        )
 
 def download_content(request: dict, http,
                 destination_file: str, 


### PR DESCRIPTION
@amywieliczka I wanted to run this by you before merging since I know you've done some work on how best to approach capturing exceptions and bubbling up the info to the airflow logs. I think it's pretty straightforward though? Printing the calisphere-id along with the error from PIL will let us hone in on which specific image is problematic.