### PR TITLE
Fix recursion bug in nuxeo fetcher

### DIFF
--- a/metadata_fetcher/fetchers/nuxeo_fetcher.py
+++ b/metadata_fetcher/fetchers/nuxeo_fetcher.py
@@ -250,7 +250,6 @@ class NuxeoFetcher(Fetcher):
             for i, folder in enumerate(folder_resp.json().get('entries', [])):
                 page_prefix.append(f"f{i}")
                 pages.extend(self.get_pages_of_records(folder, page_prefix))
-                pages.extend(self.folder_traversal(folder, page_prefix))
                 page_prefix.pop()
 
             page_prefix.pop()


### PR DESCRIPTION
We don't need to recursively call `folder_traversal()`. The initial nuxeo query fetches all folders at a particular path already. Calling it again means that deeply nested folders are fetched again, resulting in duplicate pages of records.