### PR TITLE
Set AWS_RETRY_MODE and AWS_MAX_ATTEMPTS to mitigate throttling errors

### DIFF
--- a/dags/shared_tasks/content_harvest_operators.py
+++ b/dags/shared_tasks/content_harvest_operators.py
@@ -77,6 +77,14 @@ class ContentHarvestEcsOperator(EcsRunTaskOperator):
                             {
                                 "name": "NUXEO_PASS",
                                 "value": os.environ.get("NUXEO_PASS")
+                            },
+                            {
+                                "name": "AWS_RETRY_MODE",
+                                "value": "standard"
+                            },
+                            {
+                                "name": "AWS_MAX_ATTEMPTS",
+                                "value": "10"
                             }
                         ]
                     }


### PR DESCRIPTION
We are getting `(ThrottlingException): Rate exceeded` errors from the ContentHarvestEcsOperator when harvesting very large collections. Attempting to mitigate this per this advice:

https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html#avoid-throttling-exceptions