### PR TITLE
Increase ecs waiter attempts

### DIFF
--- a/dags/dev_dags/mapper_dag.py
+++ b/dags/dev_dags/mapper_dag.py
@@ -27,7 +27,7 @@ def get_vernacular_page_batches_task(
 
     # 1024 is the maximum number of fanout tasks allowed
     # so number of batches should never be more than 1024
-    batch_size = math.ceil(len(pages) / 1024)
+    batch_size = math.ceil(len(pages) / 50)
     return batched(pages, batch_size)
 
 @task(task_id="get_mapped_pages")

--- a/dags/shared_tasks/content_harvest_operators.py
+++ b/dags/shared_tasks/content_harvest_operators.py
@@ -97,7 +97,7 @@ class ContentHarvestEcsOperator(EcsRunTaskOperator):
             "reattach": True,
             "number_logs_exception": 100,
             "waiter_delay": 10,
-            "waiter_max_attempts": 100
+            "waiter_max_attempts": 720
         }
         args.update(kwargs)
         super().__init__(**args)

--- a/dags/shared_tasks/fetching_tasks.py
+++ b/dags/shared_tasks/fetching_tasks.py
@@ -54,7 +54,7 @@ def fetch_collection_task(
 
     # 1024 is the maximum number of fanout tasks allowed
     # so number of batches should never be more than 1024
-    batch_size = math.ceil(len(fetched_collection.filepaths) / 1024)
+    batch_size = math.ceil(len(fetched_collection.filepaths) / 50)
     return batched(fetched_collection.filepaths, batch_size)
 
 

--- a/dags/shared_tasks/mapping_tasks.py
+++ b/dags/shared_tasks/mapping_tasks.py
@@ -116,7 +116,7 @@ def get_mapping_status_task(
         f"{mapped_collection.version.rstrip('/')}/data/"
     )
 
-    batch_size = math.ceil(len(mapped_collection.filepaths) / 1024)
+    batch_size = math.ceil(len(mapped_collection.filepaths) / 50)
     batched_mapped_pages = batched(mapped_collection.filepaths, batch_size)
     return [json.dumps(batch) for batch in batched_mapped_pages]
 


### PR DESCRIPTION
Increase the number of max_waiter_attempts to 720. We will poll ECS every 10 seconds (waiter_delay) up to 720 times. The end effect is that Airflow will poll ECS for a max of 2 hours to see if the task is finished before giving up.