### PR TITLE
Increase waiter max attempts to 720 for content harvester operator

### DIFF
--- a/dags/shared_tasks/content_harvest_operators.py
+++ b/dags/shared_tasks/content_harvest_operators.py
@@ -97,7 +97,7 @@ class ContentHarvestEcsOperator(EcsRunTaskOperator):
             "reattach": True,
             "number_logs_exception": 100,
             "waiter_delay": 10,
-            "waiter_max_attempts": 100
+            "waiter_max_attempts": 1440
         }
         args.update(kwargs)
         super().__init__(**args)


### PR DESCRIPTION
Increase the number of max_waiter_attempts to 1440. We will poll ECS every 10 seconds (waiter_delay) up to 1440 times. The end effect is that Airflow will poll ECS for a max of 4 hours to see if the task is finished before giving up.