### PR TITLE
Increase waiter attempts to 8640

### DIFF
--- a/dags/shared_tasks/content_harvest_operators.py
+++ b/dags/shared_tasks/content_harvest_operators.py
@@ -97,7 +97,7 @@ class ContentHarvestEcsOperator(EcsRunTaskOperator):
             "reattach": True,
             "number_logs_exception": 100,
             "waiter_delay": 10,
-            "waiter_max_attempts": 1440
+            "waiter_max_attempts": 8640
         }
         args.update(kwargs)
         super().__init__(**args)


### PR DESCRIPTION
Based on the fact that some of the content harvester tasks unexpectedly took almost 10 hours to run, I'm increasing this again to 8640. Since we poll ECS every 10 seconds, this means that Airflow will try for 24 hours. I'm not sure how big our biggest collections are, but it seems like it shouldn't hurt to give it this long.  