### PR TITLE
Add lowercase_trim normalizer to type.raw field

### DIFF
--- a/record_indexer/index_templates/record_index_config.py
+++ b/record_indexer/index_templates/record_index_config.py
@@ -68,7 +68,7 @@ RECORD_INDEX_CONFIG = {
                 "spatial": {"type": "text", "analyzer": "asciifolded_english", "fields": {"raw": {"type": "keyword"}}},
                 "subject": {"type": "text", "analyzer": "asciifolded_english", "fields": {"raw": {"type": "keyword"}}},
                 "temporal": {"type": "text", "analyzer": "asciifolded_english", "fields": {"raw": {"type": "keyword"}}},
-                "type": {"type": "text", "analyzer": "asciifolded_english", "fields": {"raw": {"type": "keyword"}}},
+                "type": {"type": "text", "analyzer": "asciifolded_english", "fields": {"raw": {"type": "keyword", "normalizer": "lowercase_trim"}}},
 
                 "sort_title": {"type": "keyword", "normalizer": "lowercase_trim"},
                 "facet_decade": {"type": "text", "analyzer": "asciifolded_english", "fields": {"raw": {"type": "keyword"}}},


### PR DESCRIPTION
This is really just one commit on top of #1012 Index Version Path, since both PRs require reindexing, though, I've made this PR against the `index-version-path` update. 

We will need to reindex both the stage and prod indexes once this update is in place. Closes #1018 