### PR TITLE
Don't raise 409 errors from OpenSearch

### DIFF
--- a/record_indexer/index_collection.py
+++ b/record_indexer/index_collection.py
@@ -90,9 +90,11 @@ def delete_by_query(index: str, data: dict[str, Any]):
         auth=settings.get_auth(),
         verify=settings.verify_certs()
     )
-    if not (200 <= r.status_code <= 299):
+    if not (200 <= r.status_code <= 299 or r.status_code == 409):
         print_opensearch_error(r, url)
         r.raise_for_status()
+    if r.status_code == 409:
+        print("Ignoring 409 Conflict Error Response")
     return r
 
 


### PR DESCRIPTION
Resolves #1095 

Typically we see a conflict because OpenSearch is still trying to reindex documents at the time that we issue a query for all outdated documents. 