### PR TITLE
One RIKOLTI_DATA to rule them all

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,16 @@ vi env.local
 
 Currently, I only use one virtual environment, even though each folder located at the root of this repository represents an isolated component. If dependency conflicts are encountered, I'll wind up creating separate environments.
 
-Similarly, I also only use one env.local as well. Rikolti fetches data to your local system, maps that data, and then fetches relevant content files (media files, previews, and thumbnails). Set `VERNACULAR_DATA` to the URI where you would like Rikolti to store and retrieve fetched data - Rikolti will create a folder (or s3 prefix) `<collection_id>/vernacular_metadata` at this location. Set `MAPPED_DATA` to the URI where you would like Rikolti to store and retrieve mapped data - Rikolti will create a folder (or s3 prefix) `<collection_id>/mapped_metadata` at this location. Set `WITH_CONTENT_URL_DATA` to the URI where you would like Rikolti to store mapped data that has been updated with urls to content files - Rikolti will create a folder (or s3 prefix) `<collection_id>/with_content_urls` at this location. Set `CONTENT_ROOT` to the URI where you would like Rikolti to store content files.
+Similarly, I also only use one env.local as well. Rikolti fetches data to your local system, maps that data, and then fetches relevant content files (media files, previews, and thumbnails). Set `RIKOLTI_DATA` to the URI where you would like Rikolti to store and retrieve data - Rikolti will create a folder (or s3 prefix) `<collection_id>/vernacular_metadata` at this location. Set `CONTENT_ROOT` to the URI where you would like Rikolti to store content files.
 
 For example, one way to configure `env.local` is:
 
 ```
-VERNACULAR_DATA=file:///Users/awieliczka/Projects/rikolti/rikolti_data
-MAPPED_DATA=$VERNACULAR_DATA
-WITH_CONTENT_URL_DATA=$VERNACULAR_DATA
+RIKOLTI_DATA=file:///Users/awieliczka/Projects/rikolti/rikolti_data
 CONTENT_ROOT=file:///Users/awieliczka/Projects/rikolti/rikolti_content
 ```
 
-Each of these can be different locations, however. For example, if you're attempting to re-run a mapper locally off of previously fetched data stored on s3, you might set `VERNACULAR_DATA=s3://rikolti_data`.
+Each of these can be different locations, however. For example, if you're attempting to re-run a mapper locally off of previously fetched data stored on s3, you might set `RIKOLTI_DATA=s3://rikolti_data`.
 
 In env.example you'll also see `METADATA_MOUNT` and `CONTENT_MOUNT` environment variables. These are only relevant if you are running the content harvester using airflow, and want to set and of the CONTENT_ environment variables to the local filesystem. Their usage is described below in the Airflow Development section.
 
@@ -170,10 +168,7 @@ These env vars are used in the `aws-mwaa-local-runner/docker/docker-compose-loca
 Next, back in the Rikolti repository, create the `startup.sh` file by running `cp env.example dags/startup.sh`. Update the startup.sh file with Nuxeo, Flickr, and Solr keys as available, and make sure that the following environment variables are set:
 
 ```
-export VERNACULAR_DATA=file:///usr/local/airflow/rikolti_data
-export MAPPED_DATA=file:///usr/local/airflow/rikolti_data
-export WITH_CONTENT_URL_DATA=file:///usr/local/airflow/rikolti_data
-export MERGED_DATA=file:///usr/local/airflow/rikolti_data
+export RIKOLTI_DATA=file:///usr/local/airflow/rikolti_data
 ```
 
 The folder located at `RIKOLTI_DATA_HOME` (set in `aws-mwaa-local-runner/docker/.env`) is mounted to `/usr/local/airflow/rikolti_data` on the airflow docker container.

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ vi env.local
 
 Currently, I only use one virtual environment, even though each folder located at the root of this repository represents an isolated component. If dependency conflicts are encountered, I'll wind up creating separate environments.
 
-Similarly, I also only use one env.local as well. Rikolti fetches data to your local system, maps that data, and then fetches relevant content files (media files, previews, and thumbnails). Set `RIKOLTI_DATA` to the URI where you would like Rikolti to store and retrieve data - Rikolti will create a folder (or s3 prefix) `<collection_id>/vernacular_metadata` at this location. Set `CONTENT_ROOT` to the URI where you would like Rikolti to store content files.
+Similarly, I also only use one env.local as well. Rikolti fetches data to your local system, maps that data, and then fetches relevant content files (media files, previews, and thumbnails). Set `RIKOLTI_DATA` to the URI where you would like Rikolti to store and retrieve data - Rikolti will create a folder (or s3 prefix) `<collection_id>/vernacular_metadata` at this location. Set `RIKOLTI_CONTENT` to the URI where you would like Rikolti to store content files.
 
 For example, one way to configure `env.local` is:
 
 ```
 RIKOLTI_DATA=file:///Users/awieliczka/Projects/rikolti/rikolti_data
-CONTENT_ROOT=file:///Users/awieliczka/Projects/rikolti/rikolti_content
+RIKOLTI_CONTENT=file:///Users/awieliczka/Projects/rikolti/rikolti_content
 ```
 
 Each of these can be different locations, however. For example, if you're attempting to re-run a mapper locally off of previously fetched data stored on s3, you might set `RIKOLTI_DATA=s3://rikolti_data`.

--- a/content_harvester/README.md
+++ b/content_harvester/README.md
@@ -34,7 +34,7 @@ The above media and thumbnail fetching processes are enacted upon child metadata
 
 # Settings
 
-You can bypass uploading to s3 by setting `RIKOLTI_DATA = "file://<local path>"` and `CONTENT_ROOT = "file://<local_path>"`. This is useful for local development and testing. This will, however, set the metadata records' `media['media_filepath']` and `thumbnail['thumbnail_filepath']` to a local filepath (thus rendering the output useless for publishing).
+You can bypass uploading to s3 by setting `RIKOLTI_DATA = "file://<local path>"` and `RIKOLTI_CONTENT = "file://<local_path>"`. This is useful for local development and testing. This will, however, set the metadata records' `media['media_filepath']` and `thumbnail['thumbnail_filepath']` to a local filepath (thus rendering the output useless for publishing).
 
 # Local Development
 

--- a/content_harvester/README.md
+++ b/content_harvester/README.md
@@ -34,7 +34,7 @@ The above media and thumbnail fetching processes are enacted upon child metadata
 
 # Settings
 
-You can bypass uploading to s3 by setting `WITH_CONTENT_URL_DATA = "file://<local path>"` and `CONTENT_ROOT = "file://<local_path>"`. This is useful for local development and testing. This will, however, set the metadata records' `media['media_filepath']` and `thumbnail['thumbnail_filepath']` to a local filepath (thus rendering the output useless for publishing).
+You can bypass uploading to s3 by setting `RIKOLTI_DATA = "file://<local path>"` and `CONTENT_ROOT = "file://<local_path>"`. This is useful for local development and testing. This will, however, set the metadata records' `media['media_filepath']` and `thumbnail['thumbnail_filepath']` to a local filepath (thus rendering the output useless for publishing).
 
 # Local Development
 

--- a/content_harvester/by_collection.py
+++ b/content_harvester/by_collection.py
@@ -1,6 +1,6 @@
 from .by_page import harvest_page_content
 from . import settings
-from rikolti.utils.versions import get_mapped_pages, create_with_content_urls_version
+from rikolti.utils.versions import get_versioned_pages, create_with_content_urls_version
 
 
 def harvest_collection_content(collection_id, mapper_type, mapped_data_version: str):
@@ -8,7 +8,7 @@ def harvest_collection_content(collection_id, mapper_type, mapped_data_version: 
         print("Error: collection_id and mapped_data_version required")
         exit()
 
-    page_list = get_mapped_pages(
+    page_list = get_versioned_pages(
         mapped_data_version, **settings.AWS_CREDENTIALS)
 
     print(f"{collection_id:<6}: Harvesting content for {len(page_list)} pages")

--- a/content_harvester/by_page.py
+++ b/content_harvester/by_page.py
@@ -4,7 +4,7 @@ from collections import Counter
 from .by_record import harvest_record_content
 
 from rikolti.utils.versions import (
-    get_versioned_page_as_json, put_with_content_urls_page, get_version
+    get_versioned_page_as_json, put_versioned_page, get_version
 )
 
 
@@ -42,7 +42,7 @@ def harvest_page_content(
                 f"record {record.get('calisphere-id')} in page {mapped_page_path}"
             )
 
-    metadata_with_content_urls = put_with_content_urls_page(
+    metadata_with_content_urls = put_versioned_page(
         json.dumps(records), page_filename, with_content_urls_version)
 
     media_source = [r for r in records if r.get('media_source')]

--- a/content_harvester/by_page.py
+++ b/content_harvester/by_page.py
@@ -4,7 +4,7 @@ from collections import Counter
 from .by_record import harvest_record_content
 
 from rikolti.utils.versions import (
-    get_mapped_page_content, put_with_content_urls_page, get_version
+    get_versioned_page_as_json, put_with_content_urls_page, get_version
 )
 
 
@@ -18,7 +18,7 @@ def harvest_page_content(
     mapped_version = get_version(collection_id, mapped_page_path)
     page_filename = mapped_page_path.split(mapped_version + '/data/')[-1]
 
-    records = get_mapped_page_content(mapped_page_path)
+    records = get_versioned_page_as_json(mapped_page_path)
     print(
         f"Harvesting content for {len(records)} records at {mapped_page_path}")
 

--- a/content_harvester/by_record.py
+++ b/content_harvester/by_record.py
@@ -400,9 +400,9 @@ def create_thumbnail_component(
 
 def upload_content(filepath: str, destination: str) -> str:
     '''
-        upload file to CONTENT_ROOT
+        upload file to RIKOLTI_CONTENT
     '''
-    content_root = os.environ.get("CONTENT_ROOT", 'file:///tmp')
+    content_root = os.environ.get("RIKOLTI_CONTENT", 'file:///tmp')
     content_path = f"{content_root.rstrip('/')}/{destination}"
     upload_file(filepath, content_path)
     return content_path

--- a/content_harvester/docker-compose.yml
+++ b/content_harvester/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ../utils:/rikolti/utils
     environment:
       - RIKOLTI_DATA=file:///rikolti_data
-      - CONTENT_ROOT=file:///rikolti_content
+      - RIKOLTI_CONTENT=file:///rikolti_content
       - NUXEO_USER=${NUXEO_USER}
       - NUXEO_PASS=${NUXEO_PASS}
       - CONTENT_COMPONENT_CACHE=${CONTENT_COMPONENT_CACHE}

--- a/content_harvester/docker-compose.yml
+++ b/content_harvester/docker-compose.yml
@@ -18,8 +18,7 @@ services:
       - ./:/content_harvester
       - ../utils:/rikolti/utils
     environment:
-      - MAPPED_DATA=file:///rikolti_data
-      - WITH_CONTENT_URL_DATA=file:///rikolti_data
+      - RIKOLTI_DATA=file:///rikolti_data
       - CONTENT_ROOT=file:///rikolti_content
       - NUXEO_USER=${NUXEO_USER}
       - NUXEO_PASS=${NUXEO_PASS}

--- a/dags/dev_dags/mapper_dag.py
+++ b/dags/dev_dags/mapper_dag.py
@@ -11,8 +11,7 @@ from rikolti.dags.shared_tasks.shared import get_registry_data_task
 from rikolti.dags.shared_tasks.shared import batched
 from rikolti.utils.versions import get_most_recent_vernacular_version
 from rikolti.utils.versions import get_most_recent_mapped_version
-from rikolti.utils.versions import get_vernacular_pages
-from rikolti.utils.versions import get_mapped_pages
+from rikolti.utils.versions import get_versioned_pages
 
 
 @task(task_id="get_vernacular_page_batches")
@@ -22,7 +21,7 @@ def get_vernacular_page_batches_task(
     vernacular_version = params.get('vernacular_version') if params else None
     if not vernacular_version:
         vernacular_version = get_most_recent_vernacular_version(collection_id)
-    pages = get_vernacular_pages(vernacular_version)
+    pages = get_versioned_pages(vernacular_version)
     # TODO: split page_list into pages and children?
 
     # 1024 is the maximum number of fanout tasks allowed
@@ -38,7 +37,7 @@ def get_mapped_pages_task(params: Optional[dict] = None):
     mapped_version = params.get('mapped_version') if params else None
     if not mapped_version:
         mapped_version = get_most_recent_mapped_version(collection_id)
-    pages = get_mapped_pages(mapped_version)
+    pages = get_versioned_pages(mapped_version)
     return pages
 
 # This is a functional duplicate of 

--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -16,7 +16,7 @@ from rikolti.dags.shared_tasks.mapping_tasks  import mapping_tasks
 from rikolti.dags.shared_tasks.content_harvest_tasks import content_harvesting_tasks
 from rikolti.utils.versions import (
     get_child_directories, get_versioned_pages,
-    get_with_content_urls_page_content, get_child_pages,
+    get_versioned_page_as_json, get_child_pages,
     create_merged_version, put_merged_page)
 from rikolti.dags.shared_tasks.indexing_tasks import stage_collection_task
 
@@ -27,7 +27,7 @@ def get_child_records(version, parent_id) -> list:
     children = [page for page in children
                 if (page.rsplit('/')[-1]).startswith(parent_id)]
     for child in children:
-        child_records.extend(get_with_content_urls_page_content(child))
+        child_records.extend(get_versioned_page_as_json(child))
     return child_records
 
 def get_child_thumbnail(child_records):
@@ -52,7 +52,7 @@ def merge_any_child_records_task(version, **context):
     merged_pages = []
     child_count_by_record = {}
     for page_path in parent_pages:
-        parent_records = get_with_content_urls_page_content(page_path)
+        parent_records = get_versioned_page_as_json(page_path)
         for record in parent_records:
             calisphere_id = record['calisphere-id']
             child_records = get_child_records(version, calisphere_id)

--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -72,7 +72,7 @@ def merge_any_child_records_task(version, **context):
         merged_pages.append(
             put_versioned_page(
                 json.dumps(parent_records),
-                os.path.basename(page_path),
+                f"{os.path.basename(page_path)}.jsonl",
                 merged_version
             )
         )

--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -17,7 +17,7 @@ from rikolti.dags.shared_tasks.content_harvest_tasks import content_harvesting_t
 from rikolti.utils.versions import (
     get_child_directories, get_versioned_pages,
     get_versioned_page_as_json, get_child_pages,
-    create_merged_version, put_merged_page)
+    create_merged_version, put_versioned_page)
 from rikolti.dags.shared_tasks.indexing_tasks import stage_collection_task
 
 
@@ -70,7 +70,7 @@ def merge_any_child_records_task(version, **context):
                 if child_thumbnail:
                     record['thumbnail'] = child_thumbnail
         merged_pages.append(
-            put_merged_page(
+            put_versioned_page(
                 json.dumps(parent_records),
                 os.path.basename(page_path),
                 merged_version

--- a/dags/harvest_dag.py
+++ b/dags/harvest_dag.py
@@ -15,7 +15,7 @@ from rikolti.dags.shared_tasks.fetching_tasks import fetching_tasks
 from rikolti.dags.shared_tasks.mapping_tasks  import mapping_tasks
 from rikolti.dags.shared_tasks.content_harvest_tasks import content_harvesting_tasks
 from rikolti.utils.versions import (
-    get_child_directories, get_with_content_urls_pages,
+    get_child_directories, get_versioned_pages,
     get_with_content_urls_page_content, get_child_pages,
     create_merged_version, put_merged_page)
 from rikolti.dags.shared_tasks.indexing_tasks import stage_collection_task
@@ -38,7 +38,7 @@ def get_child_thumbnail(child_records):
 @task(task_id="merge_any_child_records", 
       on_failure_callback=notify_rikolti_failure)
 def merge_any_child_records_task(version, **context):
-    with_content_urls_pages = get_with_content_urls_pages(version)
+    with_content_urls_pages = get_versioned_pages(version)
 
     # Recurse through the record's children (if any)
     child_directories = get_child_directories(version)

--- a/dags/shared_tasks/content_harvest_operators.py
+++ b/dags/shared_tasks/content_harvest_operators.py
@@ -70,11 +70,7 @@ class ContentHarvestEcsOperator(EcsRunTaskOperator):
                         ],
                         "environment": [
                             {
-                                "name": "MAPPED_DATA",
-                                "value": "s3://rikolti-data"
-                            },
-                            {
-                                "name": "WITH_CONTENT_URL_DATA",
+                                "name": "RIKOLTI_DATA",
                                 "value": "s3://rikolti-data"
                             },
                             {
@@ -174,15 +170,10 @@ class ContentHarvestDockerOperator(DockerOperator):
         container_name = (
             f"content_harvester_{collection_id}_{page_basename.split('.')[0]}")
 
-        if os.environ.get('MAPPED_DATA', '').startswith('s3'):
-            mapped_data = os.environ.get('MAPPED_DATA')
+        if os.environ.get('RIKOLTI_DATA', '').startswith('s3'):
+            rikolti_data = os.environ.get('RIKOLTI_DATA')
         else:
-            mapped_data = "file:///rikolti_data"
-
-        if os.environ.get('WITH_CONTENT_URL_DATA', '').startswith('s3'):
-            with_content_url_data = os.environ.get('WITH_CONTENT_URL_DATA')
-        else:
-            with_content_url_data = "file:///rikolti_data"
+            rikolti_data = "file:///rikolti_data"
 
         if os.environ.get('CONTENT_ROOT', '').startswith('s3'):
             content_root = os.environ.get('CONTENT_ROOT')
@@ -205,8 +196,7 @@ class ContentHarvestDockerOperator(DockerOperator):
             "mounts": mounts,
             "mount_tmp_dir": False,
             "environment": {
-                "MAPPED_DATA": mapped_data,
-                "WITH_CONTENT_URL_DATA": with_content_url_data,
+                "RIKOLTI_DATA": rikolti_data,
                 "CONTENT_ROOT": content_root,
                 "CONTENT_COMPONENT_CACHE": os.environ.get("CONTENT_COMPONENT_CACHE"),
                 "NUXEO_USER": os.environ.get("NUXEO_USER"),

--- a/dags/shared_tasks/content_harvest_operators.py
+++ b/dags/shared_tasks/content_harvest_operators.py
@@ -74,7 +74,7 @@ class ContentHarvestEcsOperator(EcsRunTaskOperator):
                                 "value": "s3://rikolti-data"
                             },
                             {
-                                "name": "CONTENT_ROOT",
+                                "name": "RIKOLTI_CONTENT",
                                 "value": "s3://rikolti-content"
                             },
                             {
@@ -175,10 +175,10 @@ class ContentHarvestDockerOperator(DockerOperator):
         else:
             rikolti_data = "file:///rikolti_data"
 
-        if os.environ.get('CONTENT_ROOT', '').startswith('s3'):
-            content_root = os.environ.get('CONTENT_ROOT')
+        if os.environ.get('RIKOLTI_CONTENT', '').startswith('s3'):
+            rikolti_content = os.environ.get('RIKOLTI_CONTENT')
         else:
-            content_root = "file:///rikolti_content"
+            rikolti_content = "file:///rikolti_content"
 
         prefix, pages = extract_prefix_from_pages(pages)
         args = {
@@ -197,7 +197,7 @@ class ContentHarvestDockerOperator(DockerOperator):
             "mount_tmp_dir": False,
             "environment": {
                 "RIKOLTI_DATA": rikolti_data,
-                "CONTENT_ROOT": content_root,
+                "RIKOLTI_CONTENT": rikolti_content,
                 "CONTENT_COMPONENT_CACHE": os.environ.get("CONTENT_COMPONENT_CACHE"),
                 "NUXEO_USER": os.environ.get("NUXEO_USER"),
                 "NUXEO_PASS": os.environ.get("NUXEO_PASS")

--- a/dags/shared_tasks/indexing_tasks.py
+++ b/dags/shared_tasks/indexing_tasks.py
@@ -8,7 +8,7 @@ from rikolti.dags.shared_tasks.shared import send_event_to_sns
 from rikolti.record_indexer.index_collection import (
     index_collection, delete_collection)
 from rikolti.utils.versions import (
-    get_version, get_merged_pages, get_versioned_pages)
+    get_version, get_versioned_pages)
 
 def index_collection_task(alias, collection, version_pages, context):
     collection_id = collection.get('id')
@@ -106,7 +106,7 @@ def get_version_pages(params=None):
     version = params.get('version')
 
     if 'merged' in version:
-        version_pages = get_merged_pages(version)
+        version_pages = get_versioned_pages(version, recursive=False)
     else:
         version_pages = get_versioned_pages(version)
 

--- a/dags/shared_tasks/indexing_tasks.py
+++ b/dags/shared_tasks/indexing_tasks.py
@@ -8,7 +8,7 @@ from rikolti.dags.shared_tasks.shared import send_event_to_sns
 from rikolti.record_indexer.index_collection import (
     index_collection, delete_collection)
 from rikolti.utils.versions import (
-    get_version, get_merged_pages, get_with_content_urls_pages)
+    get_version, get_merged_pages, get_versioned_pages)
 
 def index_collection_task(alias, collection, version_pages, context):
     collection_id = collection.get('id')
@@ -108,7 +108,7 @@ def get_version_pages(params=None):
     if 'merged' in version:
         version_pages = get_merged_pages(version)
     else:
-        version_pages = get_with_content_urls_pages(version)
+        version_pages = get_versioned_pages(version)
 
     return version_pages
 

--- a/dags/shared_tasks/mapping_tasks.py
+++ b/dags/shared_tasks/mapping_tasks.py
@@ -123,7 +123,7 @@ def get_mapping_status_task(
 
 def print_s3_link(version_page, mapped_version):
     # create a link to the file in the logs
-    data_root = os.environ.get("MAPPED_DATA", "file:///tmp").rstrip('/')
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp").rstrip('/')
     if data_root.startswith('s3'):
         s3_path = urlparse(f"{data_root}/{version_page}")
         bucket = s3_path.netloc

--- a/env.example
+++ b/env.example
@@ -29,7 +29,7 @@ export UCLDC_COUCH_URL="https://harvest-prd.cdlib.org/"             # this is co
 # content_harvester
 export NUXEO_USER=                                                  # ask for a user/pass - required to fetch Nuxeo Content
 export NUXEO_PASS=
-export CONTENT_ROOT=file:///usr/local/airflow/rikolti_content
+export RIKOLTI_CONTENT=file:///usr/local/airflow/rikolti_content
 export CONTENT_COMPONENT_CACHE=                                     # s3://<bucket-name>/<optional_prefix>
 
 # indexer

--- a/env.example
+++ b/env.example
@@ -2,10 +2,7 @@
 export RIKOLTI_EVENTS_SNS_TOPIC=                                    # ask for the topic ARN
 
 # metadata versions
-export VERNACULAR_DATA=file:///usr/local/airflow/rikolti_data
-export MAPPED_DATA=$VERNACULAR_DATA
-export WITH_CONTENT_URL_DATA=$VERNACULAR_DATA
-export MERGED_DATA=$VERNACULAR_DATA
+export RIKOLTI_DATA=file:///usr/local/airflow/rikolti_data
 
 # metadata_fetcher
 export NUXEO=                                                       # ask for a key - required to run the NuxeoFetcher

--- a/metadata_fetcher/fetchers/Fetcher.py
+++ b/metadata_fetcher/fetchers/Fetcher.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from requests.adapters import HTTPAdapter, Retry
-from rikolti.utils.versions import put_vernacular_page
+from rikolti.utils.versions import put_versioned_page
 
 
 logger = logging.getLogger(__name__)
@@ -84,7 +84,7 @@ class Fetcher(object):
         filepath = None
         content = self.aggregate_vernacular_content(response)
         try:
-            filepath = put_vernacular_page(
+            filepath = put_versioned_page(
                 content, self.write_page, self.vernacular_version)
         except Exception as e:
             print(f"Metadata Fetcher: {e}")

--- a/metadata_fetcher/fetchers/nuxeo_fetcher.py
+++ b/metadata_fetcher/fetchers/nuxeo_fetcher.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from urllib.parse import quote as urllib_quote
-from rikolti.utils.versions import put_vernacular_page
+from rikolti.utils.versions import put_versioned_page
 
 import requests
 
@@ -137,7 +137,7 @@ class NuxeoFetcher(Fetcher):
                 more_component_pages = False
                 continue
 
-            child_version_page = put_vernacular_page(
+            child_version_page = put_versioned_page(
                 component_resp.text,
                 f"children/{record['uid']}-{component_page_count}",
                 self.vernacular_version
@@ -191,7 +191,7 @@ class NuxeoFetcher(Fetcher):
                 more_pages_of_records = False
                 continue
 
-            version_page = put_vernacular_page(
+            version_page = put_versioned_page(
                 document_resp.text, 
                 f"{'-'.join(page_prefix)}-p{record_page_count}", 
                 self.vernacular_version

--- a/metadata_fetcher/fetchers/ucd_json_fetcher.py
+++ b/metadata_fetcher/fetchers/ucd_json_fetcher.py
@@ -10,7 +10,7 @@ from xml.etree import ElementTree
 from bs4 import BeautifulSoup
 
 from .Fetcher import Fetcher, FetchError, FetchedPageStatus
-from rikolti.utils.versions import put_vernacular_page
+from rikolti.utils.versions import put_versioned_page
 
 class UcdJsonFetcher(Fetcher):
     def __init__(self, params: dict[str]):
@@ -70,7 +70,7 @@ class UcdJsonFetcher(Fetcher):
             records = [self.fetch_json_ld(url) for url in urls]
             document_count = len(records)
             try:
-                filepath = put_vernacular_page(
+                filepath = put_versioned_page(
                     json.dumps(records), self.write_page, self.vernacular_version)
                 fetch_status.append(FetchedPageStatus(document_count, filepath))
             except Exception as e:

--- a/metadata_mapper/lambda_function.py
+++ b/metadata_mapper/lambda_function.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs, urlparse
 
 from . import settings
 from .mappers.mapper import Record, Vernacular
-from rikolti.utils.versions import get_versioned_page_content, put_mapped_page, get_version
+from rikolti.utils.versions import get_versioned_page_content, put_versioned_page, get_version
 
 logger = logging.getLogger(__name__)
 
@@ -155,7 +155,7 @@ def map_page(
 
     mapped_metadata = [record.to_dict() for record in mapped_records]
 
-    mapped_page_path = put_mapped_page(
+    mapped_page_path = put_versioned_page(
         json.dumps(mapped_metadata, ensure_ascii=False),
         page_filename, mapped_data_version)
 

--- a/metadata_mapper/lambda_function.py
+++ b/metadata_mapper/lambda_function.py
@@ -157,7 +157,7 @@ def map_page(
 
     mapped_page_path = put_versioned_page(
         json.dumps(mapped_metadata, ensure_ascii=False),
-        page_filename, mapped_data_version)
+        f"{page_filename}.jsonl", mapped_data_version)
 
     return MappedPageStatus(
         'success',

--- a/metadata_mapper/lambda_function.py
+++ b/metadata_mapper/lambda_function.py
@@ -188,7 +188,7 @@ if __name__ == "__main__":
 
     print(f"{mapped_page_status.num_mapped_records} records mapped")
     print(
-        f"mapped page at {os.environ.get('MAPPED_DATA')}/"
+        f"mapped page at {os.environ.get('RIKOLTI_DATA')}/"
         f"{mapped_page_status.mapped_page_path}")
 
     for report, couch_ids in mapped_page_status.exceptions.items():

--- a/metadata_mapper/lambda_function.py
+++ b/metadata_mapper/lambda_function.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs, urlparse
 
 from . import settings
 from .mappers.mapper import Record, Vernacular
-from rikolti.utils.versions import get_vernacular_page_content, put_mapped_page, get_version
+from rikolti.utils.versions import get_versioned_page_content, put_mapped_page, get_version
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +119,7 @@ def map_page(
         collection.get('rikolti_mapper_type'))
     vernacular_version = get_version(collection_id, vernacular_page_path)
     page_filename = vernacular_page_path.split(vernacular_version + '/data/')[-1]
-    api_resp = get_vernacular_page_content(vernacular_page_path)
+    api_resp = get_versioned_page_content(vernacular_page_path)
 
     source_vernacular = vernacular_reader(collection_id, page_filename)
     source_metadata_records = source_vernacular.parse(api_resp)

--- a/metadata_mapper/lambda_shepherd.py
+++ b/metadata_mapper/lambda_shepherd.py
@@ -10,7 +10,7 @@ from . import validate_mapping
 from .lambda_function import map_page, MappedPageStatus
 from .mappers.mapper import Record
 from rikolti.utils.versions import (
-    get_most_recent_vernacular_version, get_vernacular_pages,
+    get_most_recent_vernacular_version, get_versioned_pages,
     get_version, create_mapped_version
 )
 
@@ -173,7 +173,7 @@ def map_collection(collection_id, vernacular_version=None, validate=False):
 
     if not vernacular_version:
         vernacular_version = get_most_recent_vernacular_version(collection_id)
-    page_list = get_vernacular_pages(vernacular_version)
+    page_list = get_versioned_pages(vernacular_version)
     # TODO: split page_list into pages and children?
 
     vernacular_version = get_version(collection_id, page_list[0])

--- a/metadata_mapper/map_registry_collections.py
+++ b/metadata_mapper/map_registry_collections.py
@@ -10,7 +10,7 @@ import requests
 from .lambda_shepherd import MappedCollectionStatus
 from .lambda_shepherd import map_collection
 from .validate_mapping import create_collection_validation_csv
-from rikolti.utils.versions import get_mapped_pages
+from rikolti.utils.versions import get_versioned_pages
 from rikolti.utils.registry_client import registry_endpoint
 
 logger = logging.getLogger(__name__)
@@ -95,7 +95,7 @@ def validate_endpoint(
 
         mapped_version = mapped_versions.get(str(collection_id))
         try:
-            mapped_pages = get_mapped_pages(mapped_version)
+            mapped_pages = get_versioned_pages(mapped_version)
         except (FileNotFoundError, ValueError) as e:
             print(f"{collection_id:<6}: not mapped yet", file=sys.stderr)
             status = ValidationReportStatus(

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -12,7 +12,7 @@ from .validator.validation_log import ValidationLogLevel
 from .validator.validation_mode import ValidationMode
 from .validator.validator import Validator
 from rikolti.utils.versions import (
-    get_mapped_page_content, get_version, get_mapped_pages)
+    get_mapped_page_content, get_version, get_versioned_pages)
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -390,7 +390,7 @@ if __name__ == "__main__":
     print(f"Generating validations for collection {args.collection_id} with options:")
     print(kwargs)
 
-    mapped_page_paths = get_mapped_pages(args.mapped_data_version)
+    mapped_page_paths = get_versioned_pages(args.mapped_data_version)
 
     num_rows, file_location = create_collection_validation_csv(
         args.collection_id, mapped_page_paths, **kwargs)

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -12,7 +12,7 @@ from .validator.validation_log import ValidationLogLevel
 from .validator.validation_mode import ValidationMode
 from .validator.validator import Validator
 from rikolti.utils.versions import (
-    get_mapped_page_content, get_version, get_versioned_pages)
+    get_versioned_page_as_json, get_version, get_versioned_pages)
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -165,7 +165,7 @@ def validate_page(collection_id: int, page_path: str,
         "collection_id": collection_id,
         "page_path": page_path
     }
-    collection = get_mapped_page_content(page_path)
+    collection = get_versioned_page_as_json(page_path)
 
     if len(collection) == 0:
         print(

--- a/record_indexer/index_page.py
+++ b/record_indexer/index_page.py
@@ -7,8 +7,7 @@ import requests
 
 from . import settings
 from .utils import print_opensearch_error
-from rikolti.utils.versions import (
-    get_merged_page_content, get_with_content_urls_page_content)
+from rikolti.utils.versions import get_versioned_page_as_json
 
 
 def bulk_add(records: list, index: str):
@@ -123,10 +122,7 @@ def get_opensearch_schema(index_alias: str):
 
 
 def index_page(version_page: str, index: str, rikolti_data: dict):
-    if 'merged' in version_page:
-        records = get_merged_page_content(version_page)
-    else:
-        records = get_with_content_urls_page_content(version_page)
+    records = get_versioned_page_as_json(version_page)
 
     schema = get_opensearch_schema(index)
     removed_fields_report = defaultdict(list)

--- a/utils/s3copy.py
+++ b/utils/s3copy.py
@@ -1,0 +1,65 @@
+import os
+import boto3
+from .storage import DataStorage, parse_data_uri
+
+
+def copy_s3_to_local(data: DataStorage, destination: str, **kwargs):
+    """
+    Copy the object(s) located at data.path to the local filesystem at destination
+    """
+    s3 = boto3.client('s3', **kwargs)
+    # list all objects at data.path
+    prefix = data.path.lstrip('/')
+    s3_objects = s3.list_objects_v2(
+        Bucket=data.bucket,
+        Prefix=prefix
+    )
+    if 'Contents' not in s3_objects:
+        raise FileNotFoundError(f"Error: {data.uri} not found")
+
+    for obj in s3_objects['Contents']:
+        target_path = os.path.join(destination, obj['Key'][len(prefix):])
+        if not os.path.exists(os.path.dirname(target_path)):
+            os.makedirs(os.path.dirname(target_path), exist_ok=True)
+        s3.download_file(
+            data.bucket,
+            obj['Key'],
+            target_path
+        )
+
+    return destination
+
+
+def copy_to_local(data_uri: str, destination: str, **kwargs):
+    """
+    Copies the file located at data_uri to the local filesystem at destination.
+    """
+    data = parse_data_uri(data_uri)
+    if data.store == 's3':
+        return copy_s3_to_local(data, destination, **kwargs)
+    else:
+        raise Exception(f"Unknown data store: {data.store}")
+
+
+if __name__ == "__main__":
+    """
+    Copy content from s3 to local filesystem, preserving directory
+    structure. Overwrites files of the same name at the same location,
+    but otherwise does not clean out directories prior to copying.
+
+    Usage:
+        python s3copy.py s3://rikolti-data/26147/ ../rikolti_data/26147
+    """
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="Copy content from s3 to local filesystem")
+    parser.add_argument(
+        'data_uri',
+        help="s3://bucket-name/path/to/file"
+    )
+    parser.add_argument(
+        'destination_path',
+        help="path/to/destination"
+    )
+    args = parser.parse_args()
+    print(copy_to_local(args.data_uri, args.destination))

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -5,7 +5,7 @@ import boto3
 import shutil
 
 from urllib.parse import urlparse
-from collections import namedtuple
+from dataclasses import dataclass
 
 
 """
@@ -16,9 +16,13 @@ passed along to the underlying boto3 call and can be used for AWS credentials
 """
 
 
-DataStorage = namedtuple(
-    "DateStorage", "uri, store, bucket, path"
-)
+@dataclass
+class DataStorage:
+    uri: str
+    store: str
+    bucket: str
+    path: str
+
 
 def parse_data_uri(data_uri: str):
     data_loc = urlparse(data_uri)

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -114,11 +114,11 @@ def create_merged_version(
 
 def get_most_recent_vernacular_version(collection_id: Union[int, str]):
     """
-    Sorts the contents of $VERNACULAR_DATA/<collection_id>/, and returns the
+    Sorts the contents of $RIKOLTI_DATA/<collection_id>/, and returns the
     version path of the first item - this presumes a sortable vernacular
     version suffix.
     """
-    data_root = os.environ.get("VERNACULAR_DATA", "file:///tmp")
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     versions = storage.list_dirs(f"{data_root.rstrip('/')}/{collection_id}/")
     if not versions:
         raise Exception(
@@ -127,7 +127,7 @@ def get_most_recent_vernacular_version(collection_id: Union[int, str]):
     return f"{collection_id}/{recent_version}/"
 
 def get_most_recent_mapped_version(collection_id: Union[int, str]):
-    data_root = os.environ.get("MAPPED_DATA", "file:///tmp")
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     collection_path = f"{data_root.rstrip('/')}/{collection_id}/"
     vernacular_versions = storage.list_dirs(collection_path)
     if not vernacular_versions:
@@ -143,22 +143,22 @@ def get_most_recent_mapped_version(collection_id: Union[int, str]):
 
 def get_vernacular_pages(version, **kwargs):
     """
-    resolves a vernacular version to a data_uri at $VERNACULAR_DATA/<version>/
+    resolves a vernacular version to a data_uri at $RIKOLTI_DATA/<version>/
     returns a list of version pages.
     """
-    data_root = os.environ.get('VERNACULAR_DATA', "file:///tmp")
+    data_root = os.environ.get('RIKOLTI_DATA', "file:///tmp")
     data_path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/"
     page_list = storage.list_pages(data_path, recursive=True, **kwargs)
     return [path[len(data_root)+1:] for path in page_list]
 
 def get_mapped_pages(version, **kwargs):
     """
-    resolves a mapped version to a data_uri at $MAPPED_DATA/<version>/
+    resolves a mapped version to a data_uri at $RIKOLTI_DATA/<version>/
     returns a list of version pages located at that data_uri.
     """
     if not version:
         raise ValueError("versions.get_mapped_pages: No mapped version path provided")
-    data_root = os.environ.get("MAPPED_DATA", "file:///tmp")
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     data_path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/"
     page_list = storage.list_pages(data_path, recursive=True, **kwargs)
     return [path[len(data_root)+1:] for path in page_list]
@@ -166,34 +166,34 @@ def get_mapped_pages(version, **kwargs):
 def get_with_content_urls_pages(version, **kwargs):
     """
     resolves a with_content_urls version to a data_uri at 
-    $WITH_CONTENT_URL_DATA/<version>/
+    $RIKOLTI_DATA/<version>/
     returns a list of version pages located at that data_uri.
     """
-    data_root = os.environ.get("WITH_CONTENT_URL_DATA", "file:///tmp")
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     data_path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/"
     page_list = storage.list_pages(data_path, recursive=True, **kwargs)
     return [path[len(data_root)+1:] for path in page_list]
 
 def get_merged_pages(version, **kwargs):
     """
-    resolves a merged version to a data_uri at $MERGED_DATA/<version>/
+    resolves a merged version to a data_uri at $RIKOLTI_DATA/<version>/
     returns a list of version pages located at that data_uri.
     """
-    data_root = os.environ.get("MERGED_DATA", "file:///tmp")
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     data_path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/"
     page_list = storage.list_pages(data_path, recursive=False, **kwargs)
     return [path[len(data_root)+1:] for path in page_list]
 
 def get_child_directories(version, **kwargs):
     """
-    resolves a mapped version to a data_uri at $MAPPED_DATA/<version>/data/
+    resolves a mapped version to a data_uri at $RIKOLTI_DATA/<version>/data/
     returns a list of directories.
 
     complex objects are stored in a directory named "children" within the
     mapped version data directory. This function is used to check if any
     directory named "children" is inside the mapped version's data directory.
     """
-    data_root = os.environ.get('MAPPED_DATA', "file:///tmp")
+    data_root = os.environ.get('RIKOLTI_DATA', "file:///tmp")
     child_directories = storage.list_dirs(
         f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/",
         recursive=False
@@ -202,10 +202,10 @@ def get_child_directories(version, **kwargs):
 
 def get_child_pages(version, **kwargs):
     """
-    resolves a mapped version to a data_uri at $MAPPED_DATA/<version>/data/children/
+    resolves a mapped version to a data_uri at $RIKOLTI_DATA/<version>/data/children/
     returns a list of version pages located at data_uri.
     """
-    data_root = os.environ.get("MAPPED_DATA", "file:///tmp")
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     data_path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/children/"
     try:
         page_list = storage.list_pages(data_path, recursive=False, **kwargs)
@@ -217,79 +217,79 @@ def get_child_pages(version, **kwargs):
 
 def get_vernacular_page_content(version_page):
     """
-    resolves a version page to a data_uri at $VERNACULAR_DATA/<version_page>/
+    resolves a version page to a data_uri at $RIKOLTI_DATA/<version_page>/
     returns the contents of the page.
     """
-    data_root = os.environ.get("VERNACULAR_DATA", "file:///tmp").rstrip('/')
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp").rstrip('/')
     return storage.get_page_content(f"{data_root.rstrip('/')}/{version_page}")
 
 def get_mapped_page_content(version_page):
     """
-    resolves a version page to a data_uri at $MAPPED_DATA/<version_page>/
+    resolves a version page to a data_uri at $RIKOLTI_DATA/<version_page>/
     returns the contents of the page loaded as json
     """
-    data_root = os.environ.get("MAPPED_DATA", "file:///tmp").rstrip('/')
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp").rstrip('/')
     content = storage.get_page_content(f"{data_root.rstrip('/')}/{version_page}")
     return json.loads(content)
 
 def get_with_content_urls_page_content(version_page):
-    data_root = os.environ.get("WITH_CONTENT_URL_DATA", "file:///tmp").rstrip('/')
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp").rstrip('/')
     content = storage.get_page_content(f"{data_root}/{version_page}")
     return json.loads(content)
 
 def get_merged_page_content(version_page):
-    data_root = os.environ.get("MERGED_DATA", "file:///tmp").rstrip('/')
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp").rstrip('/')
     content = storage.get_page_content(f"{data_root}/{version_page}")
     return json.loads(content)
 
 def put_vernacular_page(content: str, page_name: Union[int, str], version: str):
     """
-    resolves a version path to a page uri at $VERNACULAR_DATA/<version>/data/<page_name>
+    resolves a version path to a page uri at $RIKOLTI_DATA/<version>/data/<page_name>
     and writes content to that data uri. returns the version page.
     """
-    data_root = os.environ.get("VERNACULAR_DATA", "file:///tmp")
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/{page_name}"
     storage.put_page_content(content, path)
     return f"{version.rstrip('/')}/data/{page_name}"
 
 def put_mapped_page(content, page_name, version):
     """
-    resolves a version path to a page uri at $MAPPED_DATA/<version>/data/<page_name>.jsonl
+    resolves a version path to a page uri at $RIKOLTI_DATA/<version>/data/<page_name>.jsonl
     and writes content to that data uri. returns the version page.
 
     content should be a json.dumped string of a list of dicts.
     """
-    data_root = os.environ.get("MAPPED_DATA", "file:///tmp")
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/{page_name}.jsonl"
     storage.put_page_content(content, path)
     return f"{version.rstrip('/')}/data/{page_name}.jsonl"
 
 def put_with_content_urls_page(content, page_name, version):
     """
-    resolves a version path to a page uri at $WITH_CONTENT_URL_DATA/<version>/data/<page_name>
+    resolves a version path to a page uri at $RIKOLTI_DATA/<version>/data/<page_name>
     and writes content to that data uri. returns the version page.
 
     content should be a json.dumped string of a list of dicts.
     """
-    data_root = os.environ.get("WITH_CONTENT_URL_DATA", "file:///tmp")
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/{page_name}"
     storage.put_page_content(content, path)
     return f"{version.rstrip('/')}/data/{page_name}"
 
 def put_merged_page(content, page_name, version):
-    data_root = os.environ.get("MERGED_DATA", "file:///tmp")
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/{page_name}.jsonl"
     storage.put_page_content(content, path)
     return f"{version.rstrip('/')}/data/{page_name}.jsonl"
 
 def put_validation_report(content, version_page):
     """
-    resolves a version path to a page uri at $MAPPED_DATA/<version page>
+    resolves a version path to a page uri at $RIKOLTI_DATA/<version page>
     and writes content to that data uri. returns the version page.
 
     content should be a csv string.
     """
-    data_root = os.environ.get("MAPPED_DATA", "file:///tmp")
+    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     path = f"{data_root.rstrip('/')}/{version_page}"
     storage.put_page_content(content, path)
     return version_page

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -187,7 +187,7 @@ def get_child_pages(version, **kwargs):
         return []
     return [path[len(data_root)+1:] for path in page_list]
 
-def get_vernacular_page_content(version_page):
+def get_versioned_page_content(version_page):
     """
     resolves a version page to a data_uri at $RIKOLTI_DATA/<version_page>/
     returns the contents of the page.
@@ -197,8 +197,7 @@ def get_vernacular_page_content(version_page):
     return content
 
 def get_versioned_page_as_json(version_page):
-    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp").rstrip('/')
-    content = storage.get_page_content(f"{data_root}/{version_page}")
+    content = get_versioned_page_content(version_page)
     return json.loads(content)
 
 def put_vernacular_page(content: str, page_name: Union[int, str], version: str):

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -193,23 +193,10 @@ def get_vernacular_page_content(version_page):
     returns the contents of the page.
     """
     data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp").rstrip('/')
-    return storage.get_page_content(f"{data_root.rstrip('/')}/{version_page}")
-
-def get_mapped_page_content(version_page):
-    """
-    resolves a version page to a data_uri at $RIKOLTI_DATA/<version_page>/
-    returns the contents of the page loaded as json
-    """
-    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp").rstrip('/')
-    content = storage.get_page_content(f"{data_root.rstrip('/')}/{version_page}")
-    return json.loads(content)
-
-def get_with_content_urls_page_content(version_page):
-    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp").rstrip('/')
     content = storage.get_page_content(f"{data_root}/{version_page}")
-    return json.loads(content)
+    return content
 
-def get_merged_page_content(version_page):
+def get_versioned_page_as_json(version_page):
     data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp").rstrip('/')
     content = storage.get_page_content(f"{data_root}/{version_page}")
     return json.loads(content)

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -1,7 +1,7 @@
 import json
 import os
 from datetime import datetime
-from typing import Union, Optional
+from typing import Union, Optional, Literal
 from . import storage
 
 """
@@ -36,6 +36,28 @@ def get_version(collection_id: Union[int, str], uri: str) -> str:
         path_list = path_list[:path_list.index('data')]
     version = "/".join(path_list)
     return version
+
+
+prefixes = Literal[
+    "vernacular_metadata_",
+    "mapped_metadata_",
+    "validation_",
+    "with_content_urls_",
+    "merged_"
+]
+def create_version(version: str, prefix: prefixes, suffix: Optional[str] = None) -> str:
+    """
+    Given a version path, ex: 3433/vernacular_metadata_v1/ and a version prefix,
+    ex: mapped_metadata_, and a version suffix, ex: v2, creates a new version
+    path, ex: 3433/vernacular_metadata_v1/mapped_metadata_v2/
+
+    If no suffix is provided, uses the current datetime.
+    """
+    version = version.rstrip('/')
+    if not suffix:
+        suffix = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+    return f"{version}/{prefix}{suffix}/"
+
 
 def create_vernacular_version(
         collection_id: Union[int, str],

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -141,34 +141,13 @@ def get_most_recent_mapped_version(collection_id: Union[int, str]):
     recent_version = sorted(mapped_versions)[-1]
     return f"{collection_id}/{vernacular_version}/{recent_version}/"
 
-def get_vernacular_pages(version, **kwargs):
+def get_versioned_pages(version, **kwargs):
     """
     resolves a vernacular version to a data_uri at $RIKOLTI_DATA/<version>/
     returns a list of version pages.
     """
-    data_root = os.environ.get('RIKOLTI_DATA', "file:///tmp")
-    data_path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/"
-    page_list = storage.list_pages(data_path, recursive=True, **kwargs)
-    return [path[len(data_root)+1:] for path in page_list]
-
-def get_mapped_pages(version, **kwargs):
-    """
-    resolves a mapped version to a data_uri at $RIKOLTI_DATA/<version>/
-    returns a list of version pages located at that data_uri.
-    """
     if not version:
-        raise ValueError("versions.get_mapped_pages: No mapped version path provided")
-    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
-    data_path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/"
-    page_list = storage.list_pages(data_path, recursive=True, **kwargs)
-    return [path[len(data_root)+1:] for path in page_list]
-
-def get_with_content_urls_pages(version, **kwargs):
-    """
-    resolves a with_content_urls version to a data_uri at 
-    $RIKOLTI_DATA/<version>/
-    returns a list of version pages located at that data_uri.
-    """
+        raise ValueError("versions.get_versioned_pages: No version path provided")
     data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     data_path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/"
     page_list = storage.list_pages(data_path, recursive=True, **kwargs)

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -45,7 +45,8 @@ prefixes = Literal[
     "with_content_urls_",
     "merged_"
 ]
-def create_version(version: str, prefix: prefixes, suffix: Optional[str] = None) -> str:
+def create_version(
+        version: str, prefix: prefixes, suffix: Optional[str] = None) -> str:
     """
     Given a version path, ex: 3433/vernacular_metadata_v1/ and a version prefix,
     ex: mapped_metadata_, and a version suffix, ex: v2, creates a new version
@@ -59,80 +60,23 @@ def create_version(version: str, prefix: prefixes, suffix: Optional[str] = None)
     return f"{version}/{prefix}{suffix}/"
 
 
-def create_vernacular_version(
-        collection_id: Union[int, str],
-        suffix: Optional[str] = None
-    ) -> str:
-    """
-    Given a collection id, ex: 3433, and version suffix, ex: v1, creates a new
-    vernacular version, ex: 3433/vernacular_metadata_v1/
+def create_vernacular_version(collection_id: Union[int, str], **kwargs) -> str:
+    return create_version(f"{collection_id}", "vernacular_metadata_", **kwargs)
 
-    If no suffix is provided, uses the current datetime.
-    """
-    version_path = f"{collection_id}"
-    if not suffix:
-        suffix = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-    return f"{version_path}/vernacular_metadata_{suffix}/"
+def create_mapped_version(vernacular_version: str, **kwargs) -> str:
+    return create_version(vernacular_version, "mapped_metadata_", **kwargs)
 
-def create_mapped_version(
-        vernacular_version: str, suffix: Optional[str] = None) -> str:
-    """
-    Given a vernacular version, ex: 3433/vernacular_metadata_v1/ and version
-    suffix, ex: v2, creates a new mapped version, ex:
-    3433/vernacular_metadata_v1/mapped_metadata_v2/
+def create_validation_version(mapped_version: str, **kwargs) -> str:
+    version = create_version(mapped_version, "validation_", **kwargs)
+    versioned_file = f"{version[:-1]}.csv"
+    return versioned_file
 
-    If no suffix is provided, uses the current datetime.
-    """
-    vernacular_version = vernacular_version.rstrip('/')
-    if not suffix:
-        suffix = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-    return f"{vernacular_version}/mapped_metadata_{suffix}/"
+def create_with_content_urls_version(mapped_version: str, **kwargs) -> str:
+    return create_version(mapped_version, "with_content_urls_", **kwargs)
 
-def create_validation_version(
-        mapped_version: str,
-        suffix: Optional[str] = None
-):
-    """
-    Given a mapped version, ex: 3433/vernacular_metadata_v1/mapped_metadata_v2/
-    and a version suffix, ex: v2, creates a new validation version, ex:
-    3433/vernacular_metadata_v1/mapped_metadata_v2/validation_v2.csv
-    Validation versions paths are also version pages.
+def create_merged_version(with_content_urls_version: str, **kwargs) -> str:
+    return create_version(with_content_urls_version, "merged_", **kwargs)
 
-    If no suffix is provided, uses the current datetime.
-    """
-    mapped_version = mapped_version.rstrip('/')
-    if not suffix:
-        suffix = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-    return f"{mapped_version}/validation_{suffix}.csv"
-
-def create_with_content_urls_version(
-        mapped_version: str, suffix: Optional[str] = None) -> str:
-    """
-    Given a mapped version, ex: 3433/vernacular_metadata_v1/mapped_metadata_v2/
-    and a version suffix, ex: v2, creates a new with content urls version, ex:
-    3433/vernacular_metadata_v1/mapped_metadata_v2/with_content_urls_v2/
-
-    If no suffix is provided, uses the current datetime.
-    """
-    mapped_version = mapped_version.rstrip('/')
-    if not suffix:
-        suffix = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-    return f"{mapped_version}/with_content_urls_{suffix}/"
-
-def create_merged_version(
-        with_content_urls_version: str, suffix: Optional[str] = None) -> str:
-    """
-    Given a with content urls version, ex: 
-    3433/vernacular_metadata_v1/mapped_metadata_v2/with_content_urls_v2/ and a
-    version suffix, ex: v1, creates a new merged version, ex:
-    3433/vernacular_metadata_v1/mapped_metadata_v2/with_content_urls_v2/merged_v1/
-
-    If no suffix is provided, uses the current datetime.
-    """
-    with_content_urls_version = with_content_urls_version.rstrip('/')
-    if not suffix:
-        suffix = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-    return f"{with_content_urls_version}/merged_{suffix}/"
 
 def get_most_recent_vernacular_version(collection_id: Union[int, str]):
     """
@@ -227,7 +171,7 @@ def put_versioned_page(content: str, page_name: Union[int, str], version: str):
     resolves a version path to a page uri at $RIKOLTI_DATA/<version>/data/<page_name>.jsonl
     and writes content to that data uri. returns the version page.
 
-    content should be a json.dumped string of a list of dicts.
+    content is a string or a json.dumped string of a list of dicts.
     """
     data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/{page_name}"

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -230,9 +230,9 @@ def put_versioned_page(content, page_name, version):
     content should be a json.dumped string of a list of dicts.
     """
     data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
-    path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/{page_name}.jsonl"
+    path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/{page_name}"
     storage.put_page_content(content, path)
-    return f"{version.rstrip('/')}/data/{page_name}.jsonl"
+    return f"{version.rstrip('/')}/data/{page_name}"
 
 def put_validation_report(content, version_page):
     """

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -200,29 +200,7 @@ def get_versioned_page_as_json(version_page):
     content = get_versioned_page_content(version_page)
     return json.loads(content)
 
-def put_vernacular_page(content: str, page_name: Union[int, str], version: str):
-    """
-    resolves a version path to a page uri at $RIKOLTI_DATA/<version>/data/<page_name>
-    and writes content to that data uri. returns the version page.
-    """
-    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
-    path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/{page_name}"
-    storage.put_page_content(content, path)
-    return f"{version.rstrip('/')}/data/{page_name}"
-
-def put_with_content_urls_page(content, page_name, version):
-    """
-    resolves a version path to a page uri at $RIKOLTI_DATA/<version>/data/<page_name>
-    and writes content to that data uri. returns the version page.
-
-    content should be a json.dumped string of a list of dicts.
-    """
-    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
-    path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/{page_name}"
-    storage.put_page_content(content, path)
-    return f"{version.rstrip('/')}/data/{page_name}"
-
-def put_versioned_page(content, page_name, version):
+def put_versioned_page(content: str, page_name: Union[int, str], version: str):
     """
     resolves a version path to a page uri at $RIKOLTI_DATA/<version>/data/<page_name>.jsonl
     and writes content to that data uri. returns the version page.

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -210,18 +210,6 @@ def put_vernacular_page(content: str, page_name: Union[int, str], version: str):
     storage.put_page_content(content, path)
     return f"{version.rstrip('/')}/data/{page_name}"
 
-def put_mapped_page(content, page_name, version):
-    """
-    resolves a version path to a page uri at $RIKOLTI_DATA/<version>/data/<page_name>.jsonl
-    and writes content to that data uri. returns the version page.
-
-    content should be a json.dumped string of a list of dicts.
-    """
-    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
-    path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/{page_name}.jsonl"
-    storage.put_page_content(content, path)
-    return f"{version.rstrip('/')}/data/{page_name}.jsonl"
-
 def put_with_content_urls_page(content, page_name, version):
     """
     resolves a version path to a page uri at $RIKOLTI_DATA/<version>/data/<page_name>
@@ -234,7 +222,13 @@ def put_with_content_urls_page(content, page_name, version):
     storage.put_page_content(content, path)
     return f"{version.rstrip('/')}/data/{page_name}"
 
-def put_merged_page(content, page_name, version):
+def put_versioned_page(content, page_name, version):
+    """
+    resolves a version path to a page uri at $RIKOLTI_DATA/<version>/data/<page_name>.jsonl
+    and writes content to that data uri. returns the version page.
+
+    content should be a json.dumped string of a list of dicts.
+    """
     data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/{page_name}.jsonl"
     storage.put_page_content(content, path)

--- a/utils/versions.py
+++ b/utils/versions.py
@@ -148,19 +148,12 @@ def get_versioned_pages(version, **kwargs):
     """
     if not version:
         raise ValueError("versions.get_versioned_pages: No version path provided")
+    recursive = True
+    if "recursive" in kwargs:
+        recursive = kwargs.pop("recursive")
     data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
     data_path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/"
-    page_list = storage.list_pages(data_path, recursive=True, **kwargs)
-    return [path[len(data_root)+1:] for path in page_list]
-
-def get_merged_pages(version, **kwargs):
-    """
-    resolves a merged version to a data_uri at $RIKOLTI_DATA/<version>/
-    returns a list of version pages located at that data_uri.
-    """
-    data_root = os.environ.get("RIKOLTI_DATA", "file:///tmp")
-    data_path = f"{data_root.rstrip('/')}/{version.rstrip('/')}/data/"
-    page_list = storage.list_pages(data_path, recursive=False, **kwargs)
+    page_list = storage.list_pages(data_path, recursive=recursive, **kwargs)
     return [path[len(data_root)+1:] for path in page_list]
 
 def get_child_directories(version, **kwargs):


### PR DESCRIPTION
This PR:

- Deprecates `VERNACULAR_DATA`, `MAPPED_DATA`, `WITH_CONTENT_URLS_DATA`, and `MERGED_DATA` environment variables in favor of `RIKOLTI_DATA`. 
- Updates `CONTENT_ROOT` to `RIKOLTI_CONTENT`
- Adds a `python -m utils.s3copy` utility that takes an s3 URI & a local filesystem path to pull down to the local filesystem some arbitrary s3 folder, maintaining relative paths. 