### PR TITLE
Don't use default value when doing dict lookup for 'thumbnail_source'

### DIFF
--- a/content_harvester/by_record.py
+++ b/content_harvester/by_record.py
@@ -84,7 +84,6 @@ def harvest_record_content(
             collection_id,
             rikolti_mapper_type: Optional[str] = None,
             ) -> dict:
-
     # Weird how we have to use username/pass to hit this endpoint
     # but we have to use auth token to hit API endpoint
     auth = None
@@ -98,7 +97,12 @@ def harvest_record_content(
         record['media'] = create_media_component(
             collection_id, request, media_source)
 
-    thumbnail_src = record.get('thumbnail_source', get_thumb_src(record))
+    # For unknown reasons, this always returns `get_thumb_src(record)`,
+    # even when the `thumbnail_source` key exists in the dictionary:
+    #   `thumbnail_src = record.get('thumbnail_source', get_thumb_src(record))`
+    thumbnail_src = record.get('thumbnail_source')
+    if not thumbnail_src:
+        thumbnail_src = get_thumb_src(record)
     thumbnail_src_url = thumbnail_src.get('url')
     if thumbnail_src_url:
         request = ContentRequest(thumbnail_src_url, auth)

--- a/content_harvester/by_record.py
+++ b/content_harvester/by_record.py
@@ -97,9 +97,6 @@ def harvest_record_content(
         record['media'] = create_media_component(
             collection_id, request, media_source)
 
-    # For unknown reasons, this always returns `get_thumb_src(record)`,
-    # even when the `thumbnail_source` key exists in the dictionary:
-    #   `thumbnail_src = record.get('thumbnail_source', get_thumb_src(record))`
     thumbnail_src = record.get('thumbnail_source')
     if not thumbnail_src:
         thumbnail_src = get_thumb_src(record)


### PR DESCRIPTION
I am still scratching my head over why this is the case, but it seems that if you use a function call as the default value for `dict.get()`, then the function call always runs, even if the key exists in the dictionary.

[Update]: OK so this makes sense. This is because, for any function call, python evaluates the arguments before the function call is executed. So for the following statement:

```
thumbnail_src = record.get('thumbnail_source', get_thumb_src(record))
```

Python runs `get_thumb_src(record)` first, before running `record.get()`.

Running `get_thumb_src(record)` updates the `record` dict "in place", so that the value of `record['thumbnail_source']` becomes:

```
{'url': {'url': 'https://nuxeo.cdlib.org/nuxeo/nxfile/default/19c41b7c-36ef-470d-bced-761046a3eb72/file:content/mss86-4_005_021.pdf?changeToken=55-0', 'mimetype': 'application/pdf', 'filename': 'mss86-4_005_021.pdf', 'nuxeo_type': 'CustomFile'}}
```
The code downstream then doesn't know how to handle a url value of type dict.

An alternative solution would be to make a deepcopy of the `record` dict:

```
import copy
thumbnail_src = record.get('thumbnail_source', get_thumb_src(copy.deepcopy(record)))
```
