### PR TITLE
Content harvest rm tmp files

### DIFF
--- a/content_harvester/by_record.py
+++ b/content_harvester/by_record.py
@@ -308,6 +308,7 @@ def create_media_component(
                 derivative_filepath, 
                 f"jp2/{collection_id}/{jp2_destination_filename}"
             )
+            os.remove(derivative_filepath)
             mimetype = 'image/jp2'
     else:
         content_s3_filepath = upload_content(
@@ -328,6 +329,7 @@ def create_media_component(
             'date_content_component_created': datetime.now().isoformat()
         }
     }
+
     return media_component
 
 
@@ -364,6 +366,7 @@ def create_thumbnail_component(
                 derivative_filepath, f"thumbnails/{collection_id}/{thumbnail_md5}"
             )
             dimensions = get_dimensions(derivative_filepath, record_context)
+            os.remove(derivative_filepath)
     elif mapped_mimetype in ['video/mp4','video/quicktime']:
         derivative_filepath = derivatives.video_to_thumb(thumbnail_tmp_filepath)
         if derivative_filepath:
@@ -371,6 +374,7 @@ def create_thumbnail_component(
                 derivative_filepath, f"thumbnails/{collection_id}/{thumbnail_md5}"
             )
             dimensions = get_dimensions(derivative_filepath, record_context)
+            os.remove(derivative_filepath)
 
     thumbnail_component = {
         'mimetype': 'image/jpeg',
@@ -384,6 +388,10 @@ def create_thumbnail_component(
             'date_content_component_created': datetime.now().isoformat()
         }
     }
+
+    if os.path.exists(thumbnail_tmp_filepath):
+        os.remove(thumbnail_tmp_filepath)
+
     return thumbnail_component
 
 


### PR DESCRIPTION
The disk is filling up during content harvesting. I think the file removal statements in this bit of code got dropped during the recent caching implementation: https://github.com/ucldc/rikolti/blob/9f7be231bd24dbb8b5e34e8b1c7554e59e4e5ada/content_harvester/by_record.py#L149-L156

The code in this PR removes source files and derivative files from local disk once they're no longer needed. I tried to find a neater way to remove the files all at once, i.e. at the end of `harvest_record_content`, but it proved tricky.

I also made a change to `derivatives.subprocess_exception_handler` so that it raises an error instead of returning None if there is an error. As was, the DAG was succeeding even when, for example, the `pdf_to_thumb` subprocess was failing. It seemed like the return value of `None` was not meant to be permanent, given the fact that `raise(e)` was commented out?