### PR TITLE
Strip date string after splitting on ;

### DIFF
--- a/metadata_mapper/mappers/date_enrichments.py
+++ b/metadata_mapper/mappers/date_enrichments.py
@@ -328,7 +328,7 @@ def convert_dates(date_values):
     else:
         # split on ; and flatten list
         date_values = [
-            date for date_str in date_values for date in date_str.split(";")]
+            date.strip() for date_str in date_values for date in date_str.split(";")]
         for date in date_values:
             start_date, end_date = parse_date_or_range(clean_date(date))
             if end_date != DEFAULT_DATETIME_STR:


### PR DESCRIPTION
Date values like this: ["1494; 1495"] look like this after enrichment: ["1494", " 1495"]

Note the space before "1495". Not sure how critical it is to remove this, but the validation report was flagging it as a problem, and maybe it affects the decade faceting?