### PR TITLE
Allow for failure of media component derivative creation

### DIFF
--- a/content_harvester/by_record.py
+++ b/content_harvester/by_record.py
@@ -95,9 +95,11 @@ def harvest_record_content(
     media_source_url = media_source.get('url')
     if media_source_url:
         request = ContentRequest(media_source_url, auth)
-        record['media'], media_tmp_files = create_media_component(
+        media_component, media_tmp_files = create_media_component(
             collection_id, request, media_source)
         tmp_files.extend(media_tmp_files)
+        if media_component.get('path'):
+            record['media'] = media_component
 
     thumbnail_src = record.get(
         'thumbnail_source', 
@@ -304,6 +306,8 @@ def create_media_component(
     tmp_filepaths = [media_tmp_filepath]
     mapped_mimetype = mapped_media_source.get('mimetype')
     mapped_nuxeotype = mapped_media_source.get('nuxeo_type')
+    mimetype = None
+    content_s3_filepath = None
 
     if mapped_nuxeotype == 'SampleCustomPicture':
         derivatives.check_media_mimetype(mapped_mimetype or '')


### PR DESCRIPTION
@amywieliczka As we discussed, the updates in this PR set the media component to have`mimetype=None` and `path=None` by default. We then check to see if the component `path` is set, and don't set `record['media']` on the record unless it is. This essentially restores the old behavior of the content harvester.

I think that if we instead added the incomplete `media` field to the index, e.g.:

```
"media": {
    'mimetype': None,
    'path': None,
    'format': "image"
}
```

then this would get through to the hosted-simple-image template in the frontend based on the fact that it's a hosted image. Then this line would cause an error because `item.contentFile.titleSources` was empty:

https://github.com/ucldc/public_interface/blob/main/calisphere/templates/calisphere/objectViewer/hosted-simple-image.html#L33

Or maybe this line would error before that:

https://github.com/ucldc/public_interface/blob/main/calisphere/record.py#L14

