### PR TITLE
Aggressive Caching

### DIFF
--- a/content_harvester/by_record.py
+++ b/content_harvester/by_record.py
@@ -98,7 +98,7 @@ def harvest_record_content(
         media_component, media_tmp_files = create_media_component(
             collection_id, request, media_source)
         tmp_files.extend(media_tmp_files)
-        if media_component.get('path'):
+        if media_component and media_component.get('path'):
             record['media'] = media_component
 
     thumbnail_src = record.get(
@@ -297,6 +297,9 @@ def create_media_component(
     '''
     media_dest_filename = mapped_media_source.get(
         'filename', get_url_basename(request.url))
+    if not media_dest_filename:
+        print(f"Could not determine filename for {request.url}")
+        return None, []
 
     source_component = download_url(request)
     if not source_component:

--- a/content_harvester/by_record.py
+++ b/content_harvester/by_record.py
@@ -287,6 +287,8 @@ def content_component_cache(component_type):
             print(f"Created {component_type} component for {request.url}")
             # set cache key to the component
             persistent_cache[cache_key] = component
+            if component and component['path'] is not None:
+                persistent_cache[cache_key] = component
             return {**component, 'from-cache': False}, tmp_files
 
         return check_component_cache


### PR DESCRIPTION
Updates the content_harvester's component cache storing and retrieval:
- cache all media and thumbnail components, even if etag and last-modified data isn't in the response header. If etag and last-modified aren't in the response header, uses `<collection_id>/<content_src_url>/<media OR thumbnail>` as the cache key
- do not cache media and thumbnail components if the component's s3 path is `None` - if the component's s3 path is `None`, an error probably occurred and we'll want to retry, or fix the error and retry. 
- use cached components if we have an exact match on a 5-part key `<collection_id>/<content_src_url>/<media OR thumbnail>/<etag>/<last-modified>` OR if we have an exact match on a 3-part key `<collection_id>/<content_src_url>/<media OR thumbnail>` and the cached component's `date_content_component_created` date is in the last 7 days. 