### PR TITLE
Remove couchdb env vars

### DIFF
--- a/dags/shared_tasks/mapping_tasks.py
+++ b/dags/shared_tasks/mapping_tasks.py
@@ -265,7 +265,7 @@ def validate_endpoint_task(url, mapped_versions, params=None, **context):
         print(f"please validate manually: {list(errored_collections.keys())}")
         print("*" * 60)
 
-    if not len(errored_collections) == len(validations):
+    if len(errored_collections) == len(validations):
         print("-", file=sys.stderr)
         raise ValueError("No collections successfully validated, exiting.")
 

--- a/dags/shared_tasks/mapping_tasks.py
+++ b/dags/shared_tasks/mapping_tasks.py
@@ -151,10 +151,7 @@ def validate_collection_task(
         "[3433/vernacular_metadata_v1/mapped_metadata_v1/3.jsonl]"
     ]
     """
-    # Skip validation step during harvest process until we can re-implement
-    # validator to compare again OpenSearch daata
-    validate = False
-    if validate:
+    if os.environ.get("UCLDC_SOLR_URL"):
         mapped_page_batches = [json.loads(batch) for batch in mapped_page_batches]
         mapped_pages = list(chain.from_iterable(mapped_page_batches))
         mapped_pages = [path for path in mapped_pages if 'children' not in path]

--- a/dags/shared_tasks/mapping_tasks.py
+++ b/dags/shared_tasks/mapping_tasks.py
@@ -151,10 +151,9 @@ def validate_collection_task(
         "[3433/vernacular_metadata_v1/mapped_metadata_v1/3.jsonl]"
     ]
     """
-    validate = bool(
-        os.environ.get("UCLDC_SOLR_URL") and 
-        os.environ.get("UCLDC_COUCH_URL")
-    )
+    # Skip validation step during harvest process until we can re-implement
+    # validator to compare again OpenSearch daata
+    validate = False
     if validate:
         mapped_page_batches = [json.loads(batch) for batch in mapped_page_batches]
         mapped_pages = list(chain.from_iterable(mapped_page_batches))

--- a/env.example
+++ b/env.example
@@ -16,8 +16,6 @@ export SKIP_UNDEFINED_ENRICHMENTS=True
 # export UCLDC_SOLR_URL="https://harvest-stg.cdlib.org/solr_api"    # this is solr stage
 export UCLDC_SOLR_URL="https://solr.calisphere.org/solr"            # this is solr prod
 export UCLDC_SOLR_API_KEY=                                          # ask for a key
-# export UCLDC_COUCH_URL="https://harvest-stg.cdlib.org/"           # this is couch stage
-export UCLDC_COUCH_URL="https://harvest-prd.cdlib.org/"             # this is couch prod
 
 # content_harvester when run locally via aws_mwaa_local_runner
 # export METADATA_MOUNT=/<path on local host>/rikolti_data          # required to run content harvester as docker operator in mwaa-local-runner

--- a/metadata_mapper/settings.py
+++ b/metadata_mapper/settings.py
@@ -8,6 +8,3 @@ SKIP_UNDEFINED_ENRICHMENTS = os.environ.get('SKIP_UNDEFINED_ENRICHMENTS', False)
 
 SOLR_URL = os.environ.get('UCLDC_SOLR_URL', False)
 SOLR_API_KEY = os.environ.get('UCLDC_SOLR_API_KEY', False)
-COUCH_URL = os.environ.get('UCLDC_COUCH_URL', False)
-
-COUCH_TIMEOUT = int(os.environ.get('UCLDC_COUCH_TIMEOUT', 60))

--- a/metadata_mapper/validate_mapping.py
+++ b/metadata_mapper/validate_mapping.py
@@ -289,21 +289,10 @@ def couch_db_request(collection_id: int, field_name: str) -> list[dict[str, str]
 
     Returns: list[dict]
     """
-    url = f"{settings.COUCH_URL}/" \
-        "couchdb/ucldc/_design/all_provider_docs/" \
-        "_list/has_field_value/by_provider_name_wdoc" \
-        f"?key=\"{collection_id}\"&field={field_name}&limit=100000"
-    
-    try:
-        response = requests.get(url, verify=False, timeout=settings.COUCH_TIMEOUT)
-        return json.loads(response.content)
-    except requests.exceptions.Timeout as e:
-        print(e)
-        print(f"Request to Couchdb has timed out after {settings.COUCH_TIMEOUT} \
-              seconds. Continuing without isShownAt and isShownBy values, \
-              which may result in increased/inaccurate validation errors.")
-        return []
-
+    print("Couchdb is no longer running. "
+           "Continuing without isShownAt and isShownBy values, "
+           "which may result in increased/inaccurate validation errors.")
+    return []
 
 def get_couch_db_data(collection_id: int,
                       harvest_ids: list[str]) -> dict[str, dict[str, str]]:


### PR DESCRIPTION
This PR removes use of `UCLDC_COUCH_URL` and `UCLDC_COUCH_TIMEOUT` env vars from the codebase, as CouchDB is no longer running.

When running the `harvest_collection` dag, the validation report generation was getting skipped. We decided to reinstate it.

When running the validator, the reports will be created without validating `isShownAt` and `isShownBy`, since those validations rely on CouchDB data. 

I did not actually do the work of stripping out all of the logic relating to couchdb. I figure it makes sense to do that when we overhaul the validator to compare against OpenSearch data.

There is also a 2nd commit in this PR that I think fixes a logic error: https://github.com/ucldc/rikolti/pull/1149/commits/64277b55ef80e2fc83a5711e9adba214d5206e20