### PR TITLE
Update nuxeo fetcher to use db query lambda

### DIFF
--- a/metadata_fetcher/fetchers/nuxeo_fetcher.py
+++ b/metadata_fetcher/fetchers/nuxeo_fetcher.py
@@ -31,13 +31,8 @@ logger = logging.getLogger(__name__)
 # internally, here.
 
 class NuxeoFetcher(Fetcher):
-    nuxeo_request_headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-        "X-NXDocumentProperties": "*",
-        "X-NXRepository": "default",
-        "X-Authentication-Token": settings.NUXEO_TOKEN
-    }
+    nuxeo_request_headers = {'Content-Type': 'application/json'}
+    nuxeo_request_cookies = {'dbquerytoken': settings.NUXEO_TOKEN}
 
     def __init__(self, params: dict):
         super(NuxeoFetcher, self).__init__(params)
@@ -61,12 +56,17 @@ class NuxeoFetcher(Fetcher):
         # initialize current path with {path, uid} of root path
         if not self.nuxeo.get('current_path'):
             escaped_path = urllib_quote(root_path, safe=' /').strip('/')
+            payload = {
+                'path': escaped_path,
+                'relation': 'self',
+                'results_type': 'full'
+            }
+
             request = {
-                'url': (
-                    "https://nuxeo.cdlib.org/Nuxeo/site/api/"
-                    f"v1/path/{escaped_path}"
-                ),
-                'headers': self.nuxeo_request_headers
+                'url': 'https://nuxeo.cdlib.org/cdl_dbquery',
+                'headers': self.nuxeo_request_headers,
+                'cookies': self.nuxeo_request_cookies,
+                'data': json.dumps(payload)
             }
             try:
                 response = self.http_session.get(**request)
@@ -74,8 +74,8 @@ class NuxeoFetcher(Fetcher):
             except Exception as e:
                 print(
                     f"{self.collection_id:<6}: A path UID is required for "
-                    f"fetching - could not retrieve root path uid: "
-                    f"{request['url']}"
+                    f"fetching - could not retrieve root path uid for: "
+                    f"{payload['path']}"
                 )
                 raise(e)
             self.nuxeo['current_path'] = {
@@ -83,27 +83,20 @@ class NuxeoFetcher(Fetcher):
                 'uid': response.json().get('uid')
             }
 
-    def get_page_of_components(self, record: dict, component_page_count: int):
-        recursive_object_nxql = (
-            "SELECT * FROM SampleCustomPicture, CustomFile, "
-            "CustomVideo, CustomAudio, CustomThreeD "
-            f"WHERE ecm:ancestorId = '{record['uid']}' "
-            "AND ecm:isTrashed = 0 ORDER BY ecm:pos"
-        )
-        query = recursive_object_nxql
-
-        # using the @search endpoint results in components being out of order
-        # in the response for some objects
-        request = {
-            'url': "https://nuxeo.cdlib.org/Nuxeo/site/api/v1/search/lang/NXQL/execute",
-            'headers': self.nuxeo_request_headers,
-            'params': {
-                'pageSize': '100',
-                'currentPageIndex': component_page_count,
-                'query': query
-            }
+    def get_page_of_components(self, record: dict, resume_after: str):
+        payload = {
+            'uid': record['uid'],
+            'doc_type': 'records',
+            'results_type': 'full',
+            'resume_after': resume_after
         }
 
+        request = {
+            'url': 'https://nuxeo.cdlib.org/cdl_dbquery',
+            'headers': self.nuxeo_request_headers,
+            'cookies': self.nuxeo_request_cookies,
+            'data': json.dumps(payload)
+        }
         try:
             response = self.http_session.get(**request)
             response.raise_for_status()
@@ -119,6 +112,10 @@ class NuxeoFetcher(Fetcher):
         each page to Rikolti storage at:
             <vernacular_version>/children/<record uuid>-<page number>
 
+        It is possible for components to be nested inside components; in the case
+        of multiple layers, the hierarchy is ignored and all layers of components
+        are flattened into one.
+
         Returns a list of FetchedPageStatus objects for each page, for example:
             [
                 FetchedPageStatus(document_count = 100, vernacular_filepath = '3433/vernacular_metadata_v1/data/children/record1-page1'),
@@ -128,48 +125,51 @@ class NuxeoFetcher(Fetcher):
         to indicate that there are 208 child records to record 1 of 3433 saved on 3 different pages
         """
         pages_of_record_components = []
-        component_page_count = 0
-        more_component_pages = True
-        while more_component_pages:
-            component_resp = self.get_page_of_components(record, component_page_count)
-            more_component_pages = component_resp.json().get('isNextPageAvailable')
-            if not component_resp.json().get('entries', []):
-                more_component_pages = False
-                continue
 
-            child_version_page = put_versioned_page(
-                component_resp.text,
-                f"children/{record['uid']}-{component_page_count}",
-                self.vernacular_version
-            )
-            pages_of_record_components.append(
-                FetchedPageStatus(
-                    len(component_resp.json().get('entries', [])),
-                    child_version_page
+        def recurse(record, root_record_uid, component_page_count):
+            more_component_pages = True
+            resume_after = ''
+            while more_component_pages:
+                component_resp = self.get_page_of_components(record, resume_after)
+                more_component_pages = component_resp.json().get('isNextPageAvailable')
+                if not component_resp.json().get('entries', []):
+                    more_component_pages = False
+                    continue
+                resume_after = component_resp.json().get('resumeAfter')
+
+                child_version_page = put_versioned_page(
+                    component_resp.text,
+                    f"children/{root_record_uid}-{component_page_count}",
+                    self.vernacular_version
                 )
-            )
-            component_page_count+=1
+
+                pages_of_record_components.append(
+                    FetchedPageStatus(
+                        len(component_resp.json().get('entries', [])),
+                        child_version_page
+                    )
+                )
+                component_page_count+=1
+
+                for component in component_resp.json().get('entries', []):
+                    recurse (component, root_record_uid, component_page_count)
+
+        recurse(record, record['uid'], 0)
         return pages_of_record_components
 
-    def get_page_of_documents(self, folder: dict, record_page_count: int):
-        # for some reason, using `ORDER BY ecm:name` in the query avoids
-        # the bug where the API was returning duplicate records from Nuxeo
-        parent_nxql = (
-            "SELECT * FROM SampleCustomPicture, CustomFile, "
-            "CustomVideo, CustomAudio, CustomThreeD "
-            f"WHERE ecm:parentId = '{folder['uid']}' AND "
-            "ecm:isTrashed = 0 ORDER BY ecm:name"
-        )
-        query = parent_nxql
+    def get_page_of_documents(self, folder: dict, resume_after: str):
+        payload = {
+            'uid': folder['uid'],
+            'doc_type': 'records',
+            'results_type': 'full',
+            'resume_after': resume_after
+        }
 
         request = {
-            'url': "https://nuxeo.cdlib.org/Nuxeo/site/api/v1/path/@search",
+            'url': 'https://nuxeo.cdlib.org/cdl_dbquery',
             'headers': self.nuxeo_request_headers,
-            'params': {
-                'pageSize': '100',
-                'currentPageIndex': record_page_count,
-                'query': query
-            }
+            'cookies': self.nuxeo_request_cookies,
+            'data': json.dumps(payload)
         }
 
         try:
@@ -184,12 +184,14 @@ class NuxeoFetcher(Fetcher):
         record_pages = []
         record_page_count = 0
         more_pages_of_records = True
+        resume_after = ''
         while more_pages_of_records:
-            document_resp = self.get_page_of_documents(folder, record_page_count)
+            document_resp = self.get_page_of_documents(folder, resume_after)
             more_pages_of_records = document_resp.json().get('isNextPageAvailable')
             if not document_resp.json().get('entries', []):
                 more_pages_of_records = False
                 continue
+            resume_after = document_resp.json().get('resumeAfter')
 
             version_page = put_versioned_page(
                 document_resp.text, 
@@ -214,24 +216,20 @@ class NuxeoFetcher(Fetcher):
             record_page_count += 1
         return record_pages
 
-    def get_page_of_folders(self, folder: dict, folder_page_count: int):
-        recursive_folder_nxql = (
-            "SELECT * FROM Organization "
-            f"WHERE ecm:path STARTSWITH '{folder['path']}' "
-            "AND ecm:isTrashed = 0"
-        )
-        query = recursive_folder_nxql
-
-        request = {
-            'url': "https://nuxeo.cdlib.org/Nuxeo/site/api/v1/path/@search",
-            'headers': self.nuxeo_request_headers,
-            'params': {
-                'pageSize': '100',
-                'currentPageIndex': folder_page_count,
-                'query': query
-            }
+    def get_page_of_folders(self, folder: dict, resume_after: str):
+        payload = {
+            'uid': folder['uid'],
+            'doc_type': 'folders',
+            'results_type': 'listing',
+            'resume_after': resume_after
         }
 
+        request = {
+            'url': 'https://nuxeo.cdlib.org/cdl_dbquery',
+            'headers': self.nuxeo_request_headers,
+            'cookies': self.nuxeo_request_cookies,
+            'data': json.dumps(payload)
+        }
         try:
             response = self.http_session.get(**request)
             response.raise_for_status()
@@ -241,22 +239,34 @@ class NuxeoFetcher(Fetcher):
         return response
 
     def folder_traversal(self, root_folder: dict, page_prefix: list):
-        folder_page_count = 0
-        more_pages_of_folders = True
         pages = []
-        while more_pages_of_folders:
-            folder_resp = self.get_page_of_folders(root_folder, folder_page_count)
-            more_pages_of_folders = folder_resp.json().get('isNextPageAvailable')
-            page_prefix.append(f"fp{folder_page_count}")
 
-            for i, folder in enumerate(folder_resp.json().get('entries', [])):
-                page_prefix.append(f"f{i}")
-                pages.extend(self.get_pages_of_records(folder, page_prefix))
+        def recurse(current_folder, page_prefix, folder_page_count):
+            more_pages_of_folders = True
+            resume_after = ''
+
+            while more_pages_of_folders:
+                folder_resp = self.get_page_of_folders(current_folder, resume_after)
+                more_pages_of_folders = folder_resp.json().get('isNextPageAvailable')
+                resume_after = folder_resp.json().get('resumeAfter')
+
+                page_prefix.append(f"fp{folder_page_count}")
+
+                for i, folder in enumerate(folder_resp.json().get('entries', [])):
+                    page_prefix.append(f"f{i}")
+                    pages.extend(self.get_pages_of_records(folder, page_prefix))
+
+                    current_folder = {'uid': folder['uid']}
+                    recurse(current_folder, page_prefix, 0)
+                    page_prefix.pop()
+
                 page_prefix.pop()
+                folder_page_count += 1
 
-            page_prefix.pop()
-            folder_page_count += 1
+        recurse(root_folder, page_prefix, 0)
         return pages
+
+
 
     def fetch_page(self) -> list[FetchedPageStatus]:
         page_prefix = ['r']


### PR DESCRIPTION
The main difference here, other than hitting the dbquery lambda endpoint, is that recursing down the hierarchy of documents is implemented here in the fetcher code rather than in the lambda.