### PR TITLE
Modify date enrichment to allow dates like '1935/07, ca.'

### DIFF
--- a/metadata_mapper/mappers/date_enrichments.py
+++ b/metadata_mapper/mappers/date_enrichments.py
@@ -200,7 +200,6 @@ def parse_date_or_range(date_str):
                 else:
                     # ie 1970-9
                     (y, m) = split_result
-                    m = m.rstrip(",")
                     # If the second number is a month, format it to two digits
                     # and use "-" as the delim for consistency in the
                     # dateparser.to_iso8601 result

--- a/metadata_mapper/mappers/date_enrichments.py
+++ b/metadata_mapper/mappers/date_enrichments.py
@@ -200,6 +200,7 @@ def parse_date_or_range(date_str):
                 else:
                     # ie 1970-9
                     (y, m) = split_result
+                    m = m.rstrip(",")
                     # If the second number is a month, format it to two digits
                     # and use "-" as the delim for consistency in the
                     # dateparser.to_iso8601 result

--- a/metadata_mapper/mappers/pastperfect_xml/pastperfect_xml_mapper.py
+++ b/metadata_mapper/mappers/pastperfect_xml/pastperfect_xml_mapper.py
@@ -10,7 +10,7 @@ class PastperfectXmlRecord(Record):
             "isShownAt": self.map_is_shown_at,
             "isShownBy": self.map_is_shown_by,
             "title": self.source_metadata.get("title"),
-            "date": self.source_metadata.get("date"),
+            "date": self.map_date,
             "description": self.source_metadata.get("title"),
             "subject": self.map_subject,
             "spatial": self.source_metadata.get("place"),
@@ -37,6 +37,16 @@ class PastperfectXmlRecord(Record):
         values = self.collate_fields(["subject", "people", "searchterms"])()
         return [{"name": value} for value in values]
 
+    def map_date(self):
+        date = self.source_metadata.get("date")
+        # remove comma in specific case that causes the date enrichment code
+        # to throw an error
+        if date:
+            date = date.strip()
+            if date.endswith(", ca."):
+                date = f"{date[:-5]} ca."
+
+        return date
 
 class PastperfectXmlVernacular(Vernacular):
     record_cls = PastperfectXmlRecord


### PR DESCRIPTION
There are some records in collection 26935 with a date format we must not have encountered before: `1935/07, ca.`, `1881/05, ca.`, `1985/12, ca.`. This PR allows for these dates to be enriched. I think the change I made is innocuous, but wow this code is complex!