### PR TITLE
Validator: Fix casting record_specific_diffs object to list for json serialization

### DIFF
--- a/dags/shared_tasks/diffs.py
+++ b/dags/shared_tasks/diffs.py
@@ -698,10 +698,13 @@ def create_aggregate_diff_reports(values_changed):
             if hasattr(obj, '__iter__') and type(obj).__name__ in ('SetOrdered'):
                 # DeepDiff uses 'SetOrdered'
                 return list(obj)
+            if isinstance(obj, dict):
+                return list(obj)
             raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
-        diff_summary_report.append(json.dumps(record_specific_diffs, indent=2, default=set_encoder))
-        diff_details_report.append(json.dumps(record_specific_diffs, indent=2, default=set_encoder))
+        record_specific_diffs = set_encoder(record_specific_diffs)
+        diff_summary_report.append(json.dumps(record_specific_diffs, indent=2))
+        diff_details_report.append(json.dumps(record_specific_diffs, indent=2))
     
     return diff_summary_report, diff_details_report
 


### PR DESCRIPTION
I'm a bit confused as to what exactly is going on here in terms of what type of object `record_specific_diffs` is (prior to any attempts to set its type to list). In case of collection 27566, it seems be an instance of `dict`. The `set_encoder` function clearly expects it to be of type `set` or `SetOrdered`, but I needed to add `dict` as an option.

The other problem was that calling `set_encoder()` as part of the `json.dumps` call (by adding the `default=set_encoder` argument) results in the `obj` being of type `type` (the type superclass). Calling `set_encoder` separately fixes this problem.

In reading through the code, it seems to me that `record_specific_diffs` is always a dict. However, if we don't explicitly cast it to a list by calling `set_encoder` on it, then calling `json.dumps` on it results in a "TypeError: Object of type type is not JSON serializable" error. So it is somehow both a dict and a type object? I'm deeply confused.

If the changes I've made here make sense, then we should probably change the name of the `set_encoder` function. All I can think of is `diffs_obj_to_list`.