### PR TITLE
Remove id enrichments

### DIFF
--- a/metadata_mapper/mappers/flickr/flickr_mapper.py
+++ b/metadata_mapper/mappers/flickr/flickr_mapper.py
@@ -8,6 +8,11 @@ from ..mapper import Record, Validator, Vernacular
 
 class FlickrRecord(Record):
     def UCLDC_map(self):
+        # All collections w/ rikolti_mapper_type__startswith="flickr." have 
+        # first enrichment: Counter({'/select-id?prop=id': 41})
+        id_handle = self.source_metadata["id"].strip().replace(" ", "__")
+        self.legacy_couch_db_id = f"{self.collection_id}--{id_handle}"
+
         return {
             "calisphere-id": self.legacy_couch_db_id.split('--')[1],
             "isShownAt": self.map_is_shown_at,

--- a/metadata_mapper/mappers/internet_archive/internet_archive_mapper.py
+++ b/metadata_mapper/mappers/internet_archive/internet_archive_mapper.py
@@ -4,6 +4,11 @@ from ..mapper import Record, Vernacular
 
 class InternetArchiveRecord(Record):
     def UCLDC_map(self) -> dict:
+        # All collections w/ rikolti_mapper_type__startswith="internet_archive."
+        # have first enrichment: Counter({'/select-id?prop=identifier': 2})
+        id_handle = self.source_metadata["identifier"].strip().replace(" ", "__")
+        self.legacy_couch_db_id = f"{self.collection_id}--{id_handle}"
+
         return {
             "calisphere-id": self.source_metadata.get("identifier"),
             "isShownAt": self.map_is_shown_at(),

--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Optional, Union
 import traceback
 
 from markupsafe import Markup
+from typing_extensions import deprecated
 
 from .date_enrichments import convert_dates, check_date_format
 from .solr_updater_helpers import make_sort_dates, unpack_display_date, get_facet_decades
@@ -189,6 +190,7 @@ class Record(ABC, object):
         self.legacy_couch_db_id = (f"{self.collection_id}--{lname}")
         return self
 
+    @deprecated("select-oac-id is deprecated and folded into the oac mapper")
     def select_oac_id(self):
         """
         called 574 times with no parameters

--- a/metadata_mapper/mappers/marc/tind_mapper.py
+++ b/metadata_mapper/mappers/marc/tind_mapper.py
@@ -11,6 +11,11 @@ from ..mapper import Record, Vernacular, Validator
 class TindRecord(Record):
 
     def UCLDC_map(self):
+        # All collections w/ rikolti_mapper_type__startswith="marc." have 
+        # first enrichment: Counter({'/select-id?prop=id': 338})
+        id_handle = self.source_metadata["id"].strip().replace(" ", "__")
+        self.legacy_couch_db_id = f"{self.collection_id}--{id_handle}"
+
         self.marc_880_fields = self.get_880_fields()
 
         return {

--- a/metadata_mapper/mappers/nuxeo/nuxeo_mapper.py
+++ b/metadata_mapper/mappers/nuxeo/nuxeo_mapper.py
@@ -11,6 +11,11 @@ class NuxeoRecord(Record):
         return super().to_UCLDC()
 
     def UCLDC_map(self):
+        # All collections w/ rikolti_mapper_type__startswith="nuxeo." have 
+        # first enrichment: Counter({'/select-id?prop=uid': 398})
+        id_handle = self.source_metadata["uid"].strip().replace(" ", "__")
+        self.legacy_couch_db_id = f"{self.collection_id}--{id_handle}"
+
         return {
             "calisphere-id": self.original_metadata.get("uid"),
             "isShownAt": (

--- a/metadata_mapper/mappers/oac/oac_mapper.py
+++ b/metadata_mapper/mappers/oac/oac_mapper.py
@@ -9,6 +9,26 @@ from ..utils import exists, getprop, iterify
 class OacRecord(Record):
 
     def to_UCLDC(self):
+        # copy select-oac-id here
+        id_values = self.source_metadata.get("identifier")
+        if not isinstance(id_values, list):
+            id_values = [id_values]
+
+        ark_ids = [v.get('text') for v in id_values
+                   if v.get('text').startswith("http://ark.cdlib.org/ark:")]
+
+        calisphere_id = None
+        if ark_ids:
+            calisphere_id = ark_ids[0]
+        else:
+            calisphere_id = id_values[0]
+
+        self.pre_mapped_data["id"] = f"{self.collection_id}--{calisphere_id}"
+        self.pre_mapped_data["calisphere-id"] = f"{calisphere_id}"
+        self.pre_mapped_data["isShownAt"] = calisphere_id
+        self.pre_mapped_data["isShownBy"] = f"{calisphere_id}/thumbnail"
+        self.legacy_couch_db_id = (f"{self.collection_id}--{calisphere_id}")
+
         mapped_data = {}
 
         id = self.pre_mapped_data.get("id", "")

--- a/metadata_mapper/mappers/oac/oac_mapper.py
+++ b/metadata_mapper/mappers/oac/oac_mapper.py
@@ -9,19 +9,15 @@ from ..utils import exists, getprop, iterify
 class OacRecord(Record):
 
     def to_UCLDC(self):
-        # copy select-oac-id here
+        # select-oac-id
         id_values = self.source_metadata.get("identifier")
         if not isinstance(id_values, list):
             id_values = [id_values]
 
         ark_ids = [v.get('text') for v in id_values
-                   if v.get('text').startswith("http://ark.cdlib.org/ark:")]
+                   if v and v.get('text').startswith("http://ark.cdlib.org/ark:")]
 
-        calisphere_id = None
-        if ark_ids:
-            calisphere_id = ark_ids[0]
-        else:
-            calisphere_id = id_values[0]
+        calisphere_id = ark_ids[0] if ark_ids else id_values[0]
 
         self.pre_mapped_data["id"] = f"{self.collection_id}--{calisphere_id}"
         self.pre_mapped_data["calisphere-id"] = f"{calisphere_id}"
@@ -29,6 +25,7 @@ class OacRecord(Record):
         self.pre_mapped_data["isShownBy"] = f"{calisphere_id}/thumbnail"
         self.legacy_couch_db_id = (f"{self.collection_id}--{calisphere_id}")
 
+        # end select-oac-id, start mapping
         mapped_data = {}
 
         id = self.pre_mapped_data.get("id", "")

--- a/metadata_mapper/mappers/oai/oai_mapper.py
+++ b/metadata_mapper/mappers/oai/oai_mapper.py
@@ -17,6 +17,11 @@ class OaiRecord(Record):
     TYPES_BASEURL = "http://id.loc.gov/vocabulary/resourceTypes/"
 
     def UCLDC_map(self):
+        # All collections w/ rikolti_mapper_type__startswith="oai." have 
+        # first enrichment: Counter({'/select-id?prop=id': 1281})
+        id_handle = self.source_metadata["id"].strip().replace(" ", "__")
+        self.legacy_couch_db_id = f"{self.collection_id}--{id_handle}"
+
         return {
             # `legacy_couch_db_id` is set by a premapping function
             "calisphere-id": self.legacy_couch_db_id.split("--")[1],

--- a/metadata_mapper/mappers/pastperfect_xml/pastperfect_xml_mapper.py
+++ b/metadata_mapper/mappers/pastperfect_xml/pastperfect_xml_mapper.py
@@ -5,6 +5,11 @@ from ..mapper import Vernacular, Record
 class PastperfectXmlRecord(Record):
 
     def UCLDC_map(self):
+        # All collections w/ rikolti_mapper_type__startswith="pastperfect" have 
+        # first enrichment: Counter({'/select-id?prop=identifier': 4})
+        id_handle = self.source_metadata["identifier"].strip().replace(" ", "__")
+        self.legacy_couch_db_id = f"{self.collection_id}--{id_handle}"
+
         return {
             "calisphere-id": self.legacy_couch_db_id.split('--')[1],
             "isShownAt": self.map_is_shown_at,

--- a/metadata_mapper/mappers/ucsd_blacklight/ucsd_blacklight_mapper.py
+++ b/metadata_mapper/mappers/ucsd_blacklight/ucsd_blacklight_mapper.py
@@ -10,6 +10,11 @@ class UcsdBlacklightMapper(Record):
     BASE_ARK = "ark:/20775/"
 
     def UCLDC_map(self) -> dict:
+        # All collections w/ rikolti_mapper_type__startswith="ucsd_blacklight." have 
+        # first enrichment: Counter({'/select-id?prop=id': 455, 'select-id?prop=id': 1})
+        id_handle = self.source_metadata["id"].strip().replace(" ", "__")
+        self.legacy_couch_db_id = f"{self.collection_id}--{id_handle}"
+
         return {
             "calisphere-id": self.legacy_couch_db_id.split("--")[1],
             "isShownAt": self.map_is_shown_at,

--- a/metadata_mapper/requirements.txt
+++ b/metadata_mapper/requirements.txt
@@ -6,3 +6,4 @@ MarkupSafe
 python-dotenv
 timelib
 pymarc
+typing-extensions


### PR DESCRIPTION
Relocate select-id directly into the mappers, so we can remove this enrichment from the enrichment chain. 

Since select-oac-id is exclusively used by collections using the oac mapper, we can fully deprecate this function. 

After this update is in place, we should go through the collection registry and remove instances of select-id and select-oac-id where possible. 