### PR TITLE
UCSD blacklight collections universally use '/jsonfy-prop': 456

### DIFF
--- a/metadata_mapper/mappers/ucsd_blacklight/ucsd_blacklight_mapper.py
+++ b/metadata_mapper/mappers/ucsd_blacklight/ucsd_blacklight_mapper.py
@@ -14,6 +14,10 @@ class UcsdBlacklightMapper(Record):
         # first enrichment: Counter({'/select-id?prop=id': 455, 'select-id?prop=id': 1})
         id_handle = self.source_metadata["id"].strip().replace(" ", "__")
         self.legacy_couch_db_id = f"{self.collection_id}--{id_handle}"
+
+        # All collections w/ rikolti_mapper_type = ucsd_blacklight.ucsd_blacklight
+        # have second enrichment: '/jsonfy_prop': 456
+        self.jsonfy_prop()
         return super().to_UCLDC()
 
     def UCLDC_map(self) -> dict:


### PR DESCRIPTION
UCSD blacklight collections are the only collections that still have pre-mapper enrichments, and thus still have the legacy mapper in the enrichment chain. 

This will allow us to totally detangle the old enrichment chain (pre-mapping enrichments, the mapper, and post-mapping enrichments) from the new enrichment chain (post-mapping enrichments _only_), and means that we can specify the mapper according to the mapper names available in Rikolti, rather than the mapper names available to DPLA ingestion 1. 

Once this is merged in, we'll need to run the following in the collection registry to remove jsonfy-prop from the enrichment chain: 

```python
from library_collection.models import *

collections = Collection.objects.filter(rikolti_mapper_type="ucsd_blacklight.ucsd_blacklight")
investigate = []
for c in collections:
    enrichments_return = f"/jsonfy-prop,\r\n/dpla_mapper?mapper_type={c.legacy_mapper_type},\r\n"
    enrichments_newline = f"/jsonfy-prop,\n/dpla_mapper?mapper_type={c.legacy_mapper_type},\n"
    if c.enrichments_item and c.enrichments_item.startswith(enrichments_return):
        c.enrichments_item = c.enrichments_item[len(enrichments_return):]
        c.save()
    elif c.enrichments_item and c.enrichments_item.startswith(enrichments_newline):
        c.enrichments_item = c.enrichments_item[len(enrichments_newline):]
        c.save()
    else:
        investigate.append(c)
        print(f"{c.id}: {c}, {c.enrichment_array[0]}, {c.enrichment_array[1]}")

if len(investigate):
    print(investigate)
```